### PR TITLE
Correct tracking and display on Multisite

### DIFF
--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -71,7 +71,7 @@ class Statify_Frontend extends Statify
 		}
 
 		/* Relative target url */
-		$data['target'] = home_url($target, 'relative');
+		$data['target'] = user_trailingslashit( str_replace( home_url( '/', 'relative' ), '/', $target ) );
 
 		/* Trim target url */
 		if ( $wp_rewrite->permalink_structure ) {

--- a/views/widget_front.view.php
+++ b/views/widget_front.view.php
@@ -41,7 +41,7 @@ $stats = Statify_Dashboard::get_stats(); ?>
                             <?php echo intval($target['count']); ?>
                         </td>
                         <td class="t">
-                            <a href="<?php echo esc_url($target['url']); ?>" target="_blank">
+                            <a href="<?php echo esc_url( home_url( $target['url'] ) ); ?>" target="_blank">
                                 <?php echo esc_html($target['url']); ?>
                             </a>
                         </td>


### PR DESCRIPTION
What this patch does:
- Track the correct absolute path on Multisite. For example, when you visit `http://example.com/subsite/`, don't track `/subsite/subsite/`, but only `/subsite/`
- In the stats widget, use `home_url` to build the right URL again for this site.
