### PR TITLE
Fix plugin activation and deactivation on multisite

### DIFF
--- a/inc/statify.class.php
+++ b/inc/statify.class.php
@@ -91,14 +91,14 @@ class Statify
 				'wpmu_new_blog',
 				array(
 					'Statify_Install',
-					'init'
+					'init_site'
 				)
 			);
 			add_action(
 				'delete_blog',
 				array(
 					'Statify_Uninstall',
-					'init'
+					'init_site'
 				)
 			);
 			add_action(

--- a/inc/statify_uninstall.class.php
+++ b/inc/statify_uninstall.class.php
@@ -1,91 +1,64 @@
 <?php
 
-
 /* Quit */
-defined('ABSPATH') OR exit;
-
+defined( 'ABSPATH' ) OR exit;
 
 /**
-* Statify_Uninstall
-*
-* @since 0.1
-*/
-
-class Statify_Uninstall
-{
-
-
+ * Statify_Uninstall
+ *
+ * @since 0.1
+ */
+class Statify_Uninstall {
 	/**
-	* Uninstallation auch für MU-Blog
-	*
-	* @since   0.1.0
-	* @change  0.1.0
-	*
-	* @param   integer  ID des Blogs
-	*/
-
-	public static function init($id)
-	{
-		/* Global */
+	 * Plugin uninstall handler.
+	 *
+	 * @since 0.1.0
+	 * @change 0.1.0
+	 */
+	public static function init() {
 		global $wpdb;
 
-		/* Neuer MU-Blog */
-		if ( ! empty($id) ) {
-			/* Im Netzwerk? */
-			if ( ! is_plugin_active_for_network(STATIFY_BASE) ) {
-				return;
-			}
+		if ( is_multisite() ) {
+			$old = get_current_blog_id();
 
-			/* Wechsel */
-			switch_to_blog( (int)$id );
+			// Todo: Use get_sites() in WordPress 4.6+
+			$ids = $wpdb->get_col( "SELECT blog_id FROM `$wpdb->blogs`" );
 
-			/* Installieren */
-			self::_apply();
-
-			/* Wechsel zurück */
-			restore_current_blog();
-
-			/* Raus */
-			return;
-		}
-
-		/* Multisite & Network */
-		if ( is_multisite() && ! empty($_GET['networkwide']) ) {
-			/* Alter Blog */
-			$old = $wpdb->blogid;
-
-			/* Blog-IDs */
-			$ids = $wpdb->get_col("SELECT blog_id FROM `$wpdb->blogs`");
-
-			/* Loopen */
-			foreach ($ids as $id) {
-				switch_to_blog($id);
+			foreach ( $ids as $id ) {
+				switch_to_blog( $id );
 				self::_apply();
 			}
 
-			/* Wechsel zurück */
-			switch_to_blog($old);
-
-			/* Raus */
-			return;
+			switch_to_blog( $old );
 		}
 
-		/* Single-Blog */
 		self::_apply();
 	}
 
+	/**
+	 * Cleans things up for a deleted site on Multisite.
+	 *
+	 * @since 1.4.4
+	 *
+	 * @param int $site_id Site ID.
+	 */
+	public function init_site( $site_id ) {
+		switch_to_blog( $site_id );
+
+		self::_apply();
+
+		restore_current_blog();
+	}
 
 	/**
-	* Löschung der Daten
-	*
-	* @since   0.1.0
-	* @change  1.4.0
-	*/
-
-	private static function _apply()
-	{
+	 * Deletes all plugin data.
+	 *
+	 * @since 0.1.0
+	 * @change 1.4.0
+	 */
+	private static function _apply() {
 		/* Delete options */
-		delete_option('statify');
+		delete_option( 'statify' );
 
 		/* Init table */
 		Statify_Table::init();


### PR DESCRIPTION
Needs testing, but seems to work.

The main problem was that the `init` methods were handling too many things, using the same param for something. I split things up, activated the plugin network-wide and the database tables were successfully created.

See #9.
