### PR TITLE
Unify Libs

### DIFF
--- a/inc/statify_dashboard.class.php
+++ b/inc/statify_dashboard.class.php
@@ -125,7 +125,7 @@ class Statify_Dashboard extends Statify
 	public static function add_js() {
 		/* Register JS */
 		wp_register_script(
-			'sm_raphael_js',
+			'raphael',
 			plugins_url(
 				'js/raphael.min.js',
 				STATIFY_FILE
@@ -140,7 +140,7 @@ class Statify_Dashboard extends Statify
 				'js/raphael.helper.min.js',
 				STATIFY_FILE
 			),
-			array(),
+			array( 'raphael' ),
 			self::$_plugin_version,
 			true
 		);
@@ -150,7 +150,7 @@ class Statify_Dashboard extends Statify
 				'js/dashboard.min.js',
 				STATIFY_FILE
 			),
-			array('jquery'),
+			array('jquery','sm_raphael_helper'),
 			self::$_plugin_version,
 			true
 		);


### PR DESCRIPTION
Would solve https://github.com/pluginkollektiv/statify/issues/28

Haha, I couldn't reproduce it, because I did already unify the libs in my local install while I was testing the problem...

This solves the problem of the popup not moving to its position. The problem I have reported in this issue is a seperated one. It appears without unification and with unification and needs seperate attention.
