### PR TITLE
Documentation v1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.5.0 / ToDo
-* Add referrer spam protection, optional, activate is t via Statify settings.
-* Change of code style, now it is WP Codex fit.
-* Multisite fix to don't track network admin url.
-* Change hook name `statify_skip_tracking` to `statify__skip_tracking`.
+* Added optional referrer spam protection (can be activated via the Statify settings).
+* Improved conformance to the WordPress coding guidelines
+* Bugfix for multi-site installations: Don't track network admin url.
+* Changed hook name `statify_skip_tracking` to `statify__skip_tracking`.
 
 ## 1.4.3 / 2016-08-15
 * Corrected tracking and display in Multisite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.5.0 / ToDo
+* Moved documentation to [wordpress.org](https://wordpress.org/plugins/statify/).
 * Added optional referrer spam protection (can be activated via the Statify settings).
 * Improved conformance to the WordPress coding guidelines
 * Bugfix for multi-site installations: Don't track network admin url.
 * Changed hook name `statify_skip_tracking` to `statify__skip_tracking`.
 
-## 1.4.3 / 2016-08-15
+## 1.4.3 / 15.08.2016
 * Corrected tracking and display in Multisite
 * Minor CSS fixes in the dashboard widget
 * Removed deprecated links and updated URLs for donate and wiki links

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ add_filter(
 );
 ```
 
-has to be your theme's `functions.php` and adapted to your needs. This example would allow all users to see the widget.
+has to be added to the theme's `functions.php` and adapted to your needs. This example would allow all users to see the widget.
 
 Editing the configuration is still limited to users with `edit_dashboard` capability.
 
@@ -43,6 +43,9 @@ Editing the configuration is still limited to users with `edit_dashboard` capabi
 For compatibility with caching plugins like [Cachify](http://cachify.de) *Statify* offers an optional switchable tracking via JavaScript. This function allows reliable count of cached blog pages.
 
 For this to work correctly, the active theme has to call `wp_footer()`.
+
+#### Skip tracking for spam referrers
+The comment blacklist can be enabled to skip tracking for views with a referrer URL listed in comment blacklist, i. e. which considered as spam.
 
 #### Skip tracking for defined users or pages
 The conditions for tracking views can be customized according to page type and user capabilities by using the hook `statify__skip_tracking`.

--- a/README.md
+++ b/README.md
@@ -2,103 +2,25 @@
 
 Visitor statistics for WordPress with focus on data protection, transparency and clarity. Perfect as a widget in your WordPress Dashboard.
 
-## Description
-The free and ad-free plugin Statify pursues a simple objective: to provide a straightforward and compact access to the number of site views.
+## Documentation and Support
+* Having questions? Then check the official [documentation on wordpress.org](https://wordpress.org/plugins/statify/).
+* Community support via the [support forums on wordpress.org](https://wordpress.org/support/plugin/statify).
+    We don’t handle support via e-mail, Twitter, GitHub issues etc.
 
-No frills. No Cookies. No third party. No storage of personal data. No endless data privacy statements.
-
-An interactive chart is followed by lists of the most common reference sources and target pages. The period of statistics and length of lists can be set directly in the dashboard widget.
-
-### Data Privacy
-In direct comparison to statistics services such as *Google Analytics*, *WordPress.com Stats* and *Piwik* *Statify* doesn't process and store personal data as e.g. IP addresses – *Statify* counts site views, not visitors.
-Absolute privacy compliance coupled with transparent procedures: A locally in WordPress created database table consists of only 4 fields (ID, date, source, target) and can be viewed at any time, cleaned up and cleared by the administrator.
-
-### Settings and Hooks
-The plugin configuration can be changed directly in the *Statify* Widget on the dashboard by clicking the *Configure* link.
-
-#### Period of data saving
-*Statify* stores the data only for a limited period (default: 2 weeks), longer intervals can be selected as option in the widget. Data which is older than the period set is deleted by a daily cron job.
-
-#### Display of the widget
-The amount of links shown in the *Statify* Widget can be set as well as the option to only count views from today. Of course, older entries are not deleted when changing this setting.
-
-The statistics for the dashboard widget are cached for four minutes.
-
-Per default only administrators can see the widget. This can be changed with the `statify__user_can_see_stats` hook.
-
-Example:
-
-```php
-add_filter(
-    'statify__user_can_see_stats',
-    '__return_true'
-);
-```
-
-has to be added to the theme's `functions.php` and adapted to your needs. This example would allow all users to see the widget.
-
-Editing the configuration is still limited to users with `edit_dashboard` capability.
-
-#### JavaScript tracking for caching compatibility
-For compatibility with caching plugins like [Cachify](http://cachify.de) *Statify* offers an optional switchable tracking via JavaScript. This function allows reliable count of cached blog pages.
-
-For this to work correctly, the active theme has to call `wp_footer()`.
-
-#### Skip tracking for spam referrers
-The comment blacklist can be enabled to skip tracking for views with a referrer URL listed in comment blacklist, i. e. which considered as spam.
-
-#### Skip tracking for defined users or pages
-The conditions for tracking views can be customized according to page type and user capabilities by using the hook `statify__skip_tracking`.
-
-Example:
-
-```php
-add_filter(
-    'statify__skip_tracking',
-    function() {
-        if ( condition ) {
-            return true;
-        }
-
-        return false;
-    }
-);
-```
-
-has to be added to the theme's `functions.php`. The condition has modified such that the method returns true if and only if the view should be ignored.
-
-### Support ###
-* Community support via the [support forums on wordpress.org](https://wordpress.org/support/plugin/statify)
-* We don’t handle support via e-mail, Twitter, GitHub issues etc.
-
-### Contribute ###
+## Contributions
 * Active development of this plugin is handled [on GitHub](https://github.com/pluginkollektiv/statify).
 * Pull requests for documented bugs are highly appreciated.
 * If you think you’ve found a bug (e.g. you’re experiencing unexpected behavior), please post at the [support forums](https://wordpress.org/support/plugin/statify) first.
-* If you want to help us translate this plugin you can do so [on WordPress Translate](https://translate.wordpress.org/projects/wp-plugins/statify).
+* If you want to translate this plugin you can do this [on WordPress Translate](https://translate.wordpress.org/projects/wp-plugins/statify).
 
-### Donate
-[Donate for us via Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML)
+## Donations
+You can leave a donation 
+[via Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML).
 
-### Credits ###
+## Credits
 * Author: [Sergej Müller](https://sergejmueller.github.io/)
 * Maintainers: [pluginkollektiv](http://pluginkollektiv.org/)
 * Contributor: [Bego Mario Garde](https://garde-medienberatung.de)
-
-
-## Installation
-* If you don’t know how to install a plugin for WordPress, [here’s how](https://codex.wordpress.org/Managing_Plugins#Installing_Plugins).
-
-### Requirements ###
-* PHP 5.2.4 or greater
-* WordPress 3.9 or greater
-
-
-## Frequently Asked Questions
-Please have a look [in the FAQ pages](https://github.com/pluginkollektiv/statify/wiki/en-FAQ).
-
-A complete documentation is available in the [GitHub repository Wiki](https://github.com/pluginkollektiv/statify/wiki).
-
 
 ## Changelog
 [Changelog](CHANGELOG.md)

--- a/inc/statify_dashboard.class.php
+++ b/inc/statify_dashboard.class.php
@@ -24,7 +24,7 @@ class Statify_Dashboard extends Statify {
 	 * @version 2016-12-21
 	 *
 	 * @wp-hook boolean  statify__user_can_see_stats
-	 * @see     https://github.com/pluginkollektiv/statify/wiki/en-Hooks#statify__user_can_see_stats
+	 * @see     https://wordpress.org/plugins/statify/
 	 */
 	public static function init() {
 

--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -24,11 +24,6 @@ class Statify_Frontend extends Statify {
 		$use_snippet = self::$_options['snippet'];
 		$is_snippet  = $use_snippet && get_query_var( 'statify_target' );
 
-		/* Skip tracking
-		if ( self::_skip_tracking() ) {
-			return self::_jump_out( $is_snippet );
-		}
-*/
 		/* Set target & referrer */
 		if ( $is_snippet ) {
 			$target   = urldecode( get_query_var( 'statify_target' ) );
@@ -151,8 +146,6 @@ class Statify_Frontend extends Statify {
 	 * @return  bool
 	 */
 	private static function check_referrer() {
-
-
 		// Return false if the blacklist filter is inactive.
 		$is_filter_reffer = get_option( 'statify' );
 

--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -107,7 +107,7 @@ class Statify_Frontend extends Statify {
 	 * @version  2016-12-21
 	 *
 	 * @hook     boolean  statify__skip_tracking
-	 * @see      https://github.com/pluginkollektiv/statify/wiki/en-Hooks#statify__skip_tracking
+	 * @see      https://wordpress.org/plugins/statify/
 	 *
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -10,6 +10,7 @@
 
 Visitor statistics for WordPress with focus on data protection, transparency and clarity. Perfect as a widget in your WordPress Dashboard.
 
+
 ## Description ##
 The free and ad-free plugin Statify pursues a simple objective: to provide a straightforward and compact access to the number of site views.
 
@@ -19,16 +20,19 @@ An interactive chart is followed by lists of the most common reference sources a
 
 ### Data Privacy ###
 In direct comparison to statistics services such as *Google Analytics*, *WordPress.com Stats* and *Piwik* *Statify* doesn't process and store personal data as e.g. IP addresses – *Statify* counts site views, not visitors.
-Absolute privacy compliance coupled with transparent procedures: A locally in WordPress created database table consists of only 4 fields (ID, date, source, target) and can be viewed at any time, cleaned up and cleared by the administrator.
+Absolute privacy compliance coupled with transparent procedures: A locally in WordPress created database table consists of only four fields (ID, date, source, target) and can be viewed at any time, cleaned up and cleared by the administrator.
 
 ### Settings and Hooks ###
 The plugin configuration can be changed directly in the *Statify* Widget on the dashboard by clicking the *Configure* link.
 
 *Period of data saving
-*Statify* stores the data only for a limited period (default: 2 weeks), longer intervals can be selected as option in the widget. Data which is older than the period set is deleted by a daily cron job.
+*Statify* stores the data only for a limited period (default: two weeks), longer intervals can be selected as option in the widget.
+Data which is older than the selected period is deleted by a daily cron job.
+An increase in the database volume can be expected because all statistic values are collected and managed in the local WordPress database (expecially if you increase the period of data saving).
 
 *Display of the widget
-The amount of links shown in the *Statify* Widget can be set as well as the option to only count views from today. Of course, older entries are not deleted when changing this setting.
+The amount of links shown in the *Statify* Widget can be set as well as the option to only count views from today.
+Of course, older entries are not deleted when changing this setting.
 
 The statistics for the dashboard widget are cached for four minutes.
 
@@ -47,9 +51,10 @@ has to be added to the theme's `functions.php` and adapted to your needs. This e
 Editing the configuration is still limited to users with `edit_dashboard` capability.
 
 *JavaScript tracking for caching compatibility
-For compatibility with caching plugins like [Cachify](http://cachify.de) *Statify* offers an optional switchable tracking via JavaScript. This function allows reliable count of cached blog pages.
+For compatibility with caching plugins like [Cachify](http://cachify.de) *Statify* offers an optional switchable tracking via JavaScript.
+This function allows reliable count of cached blog pages.
 
-For this to work correctly, the active theme has to call `wp_footer()`.
+For this to work correctly, the active theme has to call `wp_footer()`, typically in a file named `footer.php`.
 
 *Skip tracking for spam referrers
 The comment blacklist can be enabled to skip tracking for views with a referrer URL listed in comment blacklist, i. e. which considered as spam.
@@ -88,6 +93,7 @@ has to be added to the theme's `functions.php`. The condition has modified such 
 * Maintainers: [pluginkollektiv](http://pluginkollektiv.org/)
 * Contributor: [Bego Mario Garde](https://garde-medienberatung.de)
 
+
 ## Installation ##
 * If you don’t know how to install a plugin for WordPress, [here’s how](https://codex.wordpress.org/Managing_Plugins#Installing_Plugins).
 
@@ -111,12 +117,13 @@ has to be added to the theme's `functions.php`. The condition has modified such 
 This behavior can be modified with the `statify__skip_tracking` hook.
 
 ### Can further visitor data be recorded? ###
-Some plugin users want to capture additional visitor data, e.g. Devicename and resolution. *Statify* counts exclusively page views and no visitors, the desired data acquisition is not a question.
-
-A complete documentation is available in the [GitHub repository Wiki](https://github.com/pluginkollektiv/statify/wiki).
+Some plugin users want to capture additional visitor data, e.g. name of the device and resolution.
+*Statify* counts exclusively page views and no visitors, the desired data acquisition is not a question.
 
 
 ## Changelog ##
+
+You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
 
 ### 1.4.4 ###
 * Renamed the handle of the Raphael JS library. This fixed a bug, where raphael couldn't work properly when also loaded with Antispam Bee.

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ add_filter(
 );
 </pre>`
 
-has to be your theme's `functions.php` and adapted to your needs. This example would allow all users to see the widget.
+has to be added to the theme's `functions.php` and adapted to your needs. This example would allow all users to see the widget.
 
 Editing the configuration is still limited to users with `edit_dashboard` capability.
 
@@ -50,6 +50,9 @@ Editing the configuration is still limited to users with `edit_dashboard` capabi
 For compatibility with caching plugins like [Cachify](http://cachify.de) *Statify* offers an optional switchable tracking via JavaScript. This function allows reliable count of cached blog pages.
 
 For this to work correctly, the active theme has to call `wp_footer()`.
+
+*Skip tracking for spam referrers
+The comment blacklist can be enabled to skip tracking for views with a referrer URL listed in comment blacklist, i. e. which considered as spam.
 
 *Skip tracking for defined users or pages
 The conditions for tracking views can be customized according to page type and user capabilities by using the hook `statify__skip_tracking`.

--- a/views/widget_back.view.php
+++ b/views/widget_back.view.php
@@ -44,7 +44,7 @@ class_exists( 'Statify' ) || exit; ?>
 
 				<label for="statify_blacklist">
 					<input type="checkbox" name="statify[blacklist]" id="statify_blacklist" value="1" <?php checked( Statify::$_options['blacklist'], 1 ); ?> />
-					<?php esc_html_e( 'Use the \'Comment Blacklist\' to filter referrer.', 'statify' ); ?>
+					<?php esc_html_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>
 				</label>
 			</fieldset>
 		</td>

--- a/views/widget_back.view.php
+++ b/views/widget_back.view.php
@@ -51,10 +51,8 @@ class_exists( 'Statify' ) || exit; ?>
 	</tr>
 </table>
 
-
 <p class="meta-links">
-	<a href="<?php esc_html_e( 'https://wordpress.org/plugins/statify/faq/', 'statify' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'statify' ); ?></a>
+	<a href="<?php esc_html_e( 'https://wordpress.org/plugins/statify/', 'statify' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Documentation', 'statify' ); ?></a>
 	&bull; <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'statify' ); ?></a>
 	&bull; <a href="https://wordpress.org/support/plugin/statify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'statify' ); ?></a>
-	&bull; <a href="https://github.com/pluginkollektiv/statify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'statify' ); ?></a>
 </p>


### PR DESCRIPTION
This PR updates the documentation for release v1.5. All documentation is included into the readme.txt such that it becomes translateable on wordpress.org.

As all information from the [Wiki ](https://github.com/pluginkollektiv/statify/wiki) is included, the wiki can be deleted after adding the German translation on translate.wordpress.org. After that documentation is on one place - which makes it easier to keep it consistent.