### PR TITLE
Bugfix: _skip_tracking function is not considered if JS tracking disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.1 / TODO
+* Bugfix: Consider filter for skipping tracking correctly if JavaScript tracking is disabled.
+
 ## 1.5.0 / 2017-03-23
 * Switched to minimal PHP version 5.3
 * Added more flexible settings for period of data saving and the number of entries shown in top lists

--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -42,6 +42,11 @@ class Statify_Frontend extends Statify {
 			return self::_jump_out( $is_snippet );
 		}
 
+		/* Check whether tracking should be skipped for this view. */
+		if ( self::_skip_tracking() ) {
+			return false;
+		}
+
 		/* Global vars */
 		global $wpdb, $wp_rewrite;
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 3.9
 * Tested up to:      4.7.3
-* Stable tag:        1.5.0
+* Stable tag:        1.5.1
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -123,6 +123,9 @@ Some plugin users want to capture additional visitor data, e.g. name of the devi
 ## Changelog ##
 
 You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
+
+### 1.5.1 ###
+* Bugfix: Consider filter for skipping tracking correctly if JavaScript tracking is disabled.
 
 ### 1.5.0 (2017-03-23) ###
 * Switched to minimal PHP version 5.3

--- a/statify.php
+++ b/statify.php
@@ -3,12 +3,11 @@
  * Plugin Name: Statify
  * Description: Compact, easy-to-use and privacy-compliant stats plugin for WordPress.
  * Text Domain: statify
- * Domain Path: /lang
  * Author:      pluginkollektiv
  * Author URI:  http://pluginkollektiv.org
- * Plugin URI:  https://wordpress.org/plugins/statify
+ * Plugin URI:  https://wordpress.org/plugins/statify/
  * License:     GPLv3 or later
- * Version:     1.5.0
+ * Version:     1.5.1
  *
  * Copyright (C)  2011-2017 Sergej Müller, pluginkollektiv
  *


### PR DESCRIPTION
- Fixes issue #47
- Increases version number to 1.5.1 for a bugfix release
- Unifies the plugin URL such that it doesn't appear twice for translation