### PR TITLE
Update compatibility info to WP 4.7+

### DIFF
--- a/inc/statify_install.class.php
+++ b/inc/statify_install.class.php
@@ -20,14 +20,8 @@ class Statify_Install {
 	public static function init( $network_wide = false ) {
 
 		if ( $network_wide && is_multisite() ) {
-			// @ToDo: leave only get_sites, after decision which versions of WP will we supporting.
-			if ( function_exists( 'get_sites' ) ) {
-				$sites = get_sites();
-			} elseif ( function_exists( 'wp_get_sites' ) ) {
-				$sites = wp_get_sites();
-			} else {
-				return;
-			}
+			$sites = get_sites();
+
 			// Create tables for each site in a network.
 			foreach ( $sites as $site ) {
 				// Convert object to array.

--- a/inc/statify_uninstall.class.php
+++ b/inc/statify_uninstall.class.php
@@ -16,18 +16,9 @@ class Statify_Uninstall {
 	 * @version 0.1.0
 	 */
 	public static function init() {
-
 		if ( is_multisite() ) {
 			$old = get_current_blog_id();
-			// @ToDo: leave only get_sites, after decision which versions of WP will we supporting.
-			// @ToDo Redundant with Statify_Install class. We should reduce the maintenance.
-			if ( function_exists( 'get_sites' ) ) {
-				$sites = get_sites();
-			} elseif ( function_exists( 'wp_get_sites' ) ) {
-				$sites = wp_get_sites();
-			} else {
-				return;
-			}
+			$sites = get_sites();
 
 			foreach ( $sites as $site ) {
 				// Convert object to array.

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 * Contributors:      pluginkollektiv
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
-* Requires at least: 3.9
-* Tested up to:      4.7
-* Stable tag:        1.5.1
+* Requires at least: 4.7
+* Tested up to:      4.8
+* Stable tag:        1.5.2
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/statify.php
+++ b/statify.php
@@ -7,7 +7,7 @@
  * Author URI:  http://pluginkollektiv.org
  * Plugin URI:  https://wordpress.org/plugins/statify/
  * License:     GPLv3 or later
- * Version:     1.5.1
+ * Version:     1.5.2
  *
  * Copyright (C)  2011-2017 Sergej Müller, pluginkollektiv
  *


### PR DESCRIPTION
- Updating the minimum WP version to 4.7 fixes a compatibility issue as we use the second parameter of `wp_parse_url` which is [not available before WP 4.7](https://developer.wordpress.org/reference/functions/wp_parse_url/#changelog) ([bug report](https://wordpress.org/support/topic/problem-beste-inhalte/)).
- In WP 4.7+ the fallback for `get_sites()` is not necessary anymore.