### PR TITLE
Do not set code 204 on JS snippet (fix #58)

### DIFF
--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -224,7 +224,7 @@ class Statify_Frontend extends Statify {
 
 		if ( $is_snippet ) {
 			nocache_headers();
-			header( 'Content-type: text/javascript', true, 204 );
+			header( 'Content-type: text/javascript', true );
 			exit;
 		}
 


### PR DESCRIPTION
Content-Type header might be omitted if status code is 204 (no content) which effectively breaks JS tracking in 'nosniff' environments, because the "script" inclusion is prohibited by modern browsers.

Makes sense somehow to set 204 on empty respnse, but it also makes sense to ignore the type of "nothing"... Simply removing the explicit status code and leaving the default 200 solves the issue.