### PR TITLE
Add hook after data was added (solves #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.5
+* statify__visit_saved hook was added. This hook gets fired after a visit was stored in the database.
+
 ## 1.5.3 / 2017-11-28
 * Replace javascript library to fixed several problems. #52
 

--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -81,6 +81,14 @@ class Statify_Frontend extends Statify {
 		/* Insert */
 		$wpdb->insert( $wpdb->statify, $data );
 
+		/**
+		 * Fires after a visit was stored in the database
+		 *
+		 * @param array $data
+		 * @param int $wpdb->insert_id
+		 */
+		do_action( 'statify__visit_saved', $data, $wpdb->insert_id );
+
 		/* Jump! */
 		return self::_jump_out( $is_snippet );
 	}

--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -84,6 +84,8 @@ class Statify_Frontend extends Statify {
 		/**
 		 * Fires after a visit was stored in the database
 		 *
+		 * @since 1.5.5
+		 *
 		 * @param array $data
 		 * @param int $wpdb->insert_id
 		 */


### PR DESCRIPTION
Introduces a new action hook `statify__visit_saved` which is fired right after the data is saved to the database.

See #61 for a use case.