### PR TITLE
fix license declaration in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pluginkollektiv/statify",
   "description": "Compact, easy-to-use and privacy-compliant stats plugin for WordPress.",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "type": "wordpress-plugin",
   "keywords": [
     "wordpress",


### PR DESCRIPTION
 License "GPL-3.0" is a deprecated SPDX license identifier, use "GPL-3.0-only" or "GPL-3.0-or-later" instead
