### PR TITLE
Drop minimum requirements from FAQ

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -53,10 +53,6 @@ If you've problems or think you’ve found a bug (e.g. you’re experiencing une
 
 ## Frequently Asked Questions ##
 
-### What are the minimum requirements? ###
-* PHP 5.3 or greater
-* WordPress 3.9 or greater
-
 ### Which areas are excluded from counting? ###
 *Statify* does not count the following views:
 


### PR DESCRIPTION
Both required PHP version and required WP version are prominently displayed in sidebar on plugin page. The information in FAQ is redundant and prone to become outdated (as it is now...)