### PR TITLE
Dynamic radius of datapoints in dashboard widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Scaled datapoint size to number of records in dashboard widget to improve legibility 
+
 ## 1.6.0
 * Added hook statify__visit_saved which is fired after a visit was stored in the database.
 * Migrated dashboard chart to Chartist.

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -53,13 +53,18 @@
 		]
 	});
 
+	var pointRadius = 4;
+	if (data.length > 365) pointRadius = 0;
+	else if (data.length > 180) pointRadius = 1;
+	else if (data.length > 90) pointRadius = 2;
+
 	// Replace default points with hollow circles, add "pageview(s) to value and append date (label) as meta data.
 	chart.on('draw', function (data) {
 		if ('point' === data.type) {
 			var circle = new Chartist.Svg('circle', {
 				cx: [data.x],
 				cy: [data.y],
-				r: [4],
+				r: [pointRadius],
 				'ct:value': data.value.y + ' ' + (data.value.y > 1 ? statify_translations.pageviews : statify_translations.pageview),
 				'ct:meta': labels[data.index]
 			}, 'ct-point');


### PR DESCRIPTION
This PR adresses #66.
The radius of the data points (currently 4px) is now dynmically adjusted according to the actual number of datapoints.

| # of points | radius |
| ----------- | ------ |
| >365        | 0px    |
| >180        | 1px    |
| >90         | 2px    |
| <=90        | 4px    |

This results in a dashboard like this:
![dynamic_pointsize](https://user-images.githubusercontent.com/12963621/37094946-d2aeb332-2214-11e8-95b7-0681df223ebf.png)
