### PR TITLE
Left-align Y-axis in order to not clip larger numbers

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -10,6 +10,13 @@
     display: none;
 }
 
+#statify_chart .ct-label.ct-vertical.ct-start {
+    -webkit-justify-content: flex-start;
+    justify-content: flex-start;
+    text-align: left;
+    text-anchor: start;
+}
+
 #statify_chart .ct-line {
     stroke: #0074a2;
     stroke-width: 2px;


### PR DESCRIPTION
This PR fixes #73.

The Y-axis label is clipped, as it is right-aligned and by default limited to 5px. Recommended way in Chartist (according to some GH issues there) is to add an offset to the axis.
In my opinion this would waste space here, so I worked around this issue by left-aligning the number in our custom CSS.

![screenshot_2018-03-14_19-26-14](https://user-images.githubusercontent.com/12963621/37423549-6f37df18-27be-11e8-9964-baf7c65689df.png)
