### PR TITLE
Bundle JS source maps for pre-minified assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 css/*.min.css
 js/*.min.js
+js/*.min.js.map
 vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## unreleased
 * Scaled datapoint size to number of records in dashboard widget to improve legibility 
+* Added JS source maps to avoid warnings with developer tools 
 
 ## 1.6.0
 * Added hook statify__visit_saved which is fired after a visit was stored in the database.

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,9 @@
     "copy-file": {
       "vendor/npm-asset/chartist/dist/chartist.min.css": "css/",
       "vendor/npm-asset/chartist/dist/chartist.min.js": "js/",
-      "vendor/npm-asset/chartist-plugin-tooltips/dist/chartist-plugin-tooltip.min.js": "js/"
+      "vendor/npm-asset/chartist/dist/chartist.min.js.map": "js/",
+      "vendor/npm-asset/chartist-plugin-tooltips/dist/chartist-plugin-tooltip.min.js": "js/",
+      "vendor/npm-asset/chartist-plugin-tooltips/dist/chartist-plugin-tooltip.min.js.map": "js/"
     }
   }
 }


### PR DESCRIPTION
Fixes issue report in the WP support forums: https://wordpress.org/support/topic/error-failed-to-load-resource-2/

The pre-minified Javascript fiels for Chartist and the tooltip plugin reference source maps
```
//# sourceMappingURL=chartist.min.js.map
```
which leads to 404 errors when accessing the admin panel with dev-tools active, because the `.map`files are not shipped.

This "bug" does not affect normal users, only admins with debug tools, so we could probably remove the maps from the distributable files, but for the same reason they wont't hurt (usually not requested), so i think it's fine to just bundle the extra ~250kB and not modify third party assets.