### PR TITLE
move js snippet to separate file

### DIFF
--- a/js/snippet.js
+++ b/js/snippet.js
@@ -1,0 +1,8 @@
+const statifyReq = new XMLHttpRequest();
+statifyReq.open(
+	'GET',
+	document.getElementById('statify-js-snippet').getAttribute('data-home-url')
+	+ '?statify_referrer=' + encodeURIComponent(document.referrer)
+	+ '&statify_target=' + encodeURIComponent(location.pathname + location.search)
+);
+statifyReq.send( null );

--- a/views/js_snippet.view.php
+++ b/views/js_snippet.view.php
@@ -3,15 +3,11 @@
 class_exists( 'Statify' ) || exit; ?>
 
 	<!-- Stats by http://statify.de -->
-	<script type="text/javascript">
-		const statifyReq = new XMLHttpRequest();
-		statifyReq.open(
-			'GET',
-			'<?php echo esc_url( home_url( '/', 'relative' ) ); ?>'
-			+ '?statify_referrer=' + encodeURIComponent(document.referrer)
-			+ '&statify_target=' + encodeURIComponent(location.pathname + location.search)
-		);
-		statifyReq.send( null );
+	<script
+		id="statify-js-snippet"
+		data-home-url="<?php echo esc_url( home_url( '/', 'relative' ) ); ?>"
+		type="text/javascript"
+		src="<?php echo plugins_url( 'js/snippet.js', STATIFY_FILE ); ?>">
 	</script>
 
 <?php /** Markup space */ ?>


### PR DESCRIPTION
This allows to use a more restrictive CSP (especially without unsafe-inline script).

See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP<Paste>