### PR TITLE
Fix #84: separate internal-rules from other skip_tracking rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## unreleased
 * Scaled datapoint size to number of records in dashboard widget to improve legibility 
-* Added JS source maps to avoid warnings with developer tools 
+* Added JS source maps to avoid warnings with developer tools
+* Add JS snippet to output even if tracking is skipped to avoid caching problems
 
 ## 1.6.0
 * Added hook statify__visit_saved which is fired after a visit was stored in the database.

--- a/inc/statify_frontend.class.php
+++ b/inc/statify_frontend.class.php
@@ -145,9 +145,20 @@ class Statify_Frontend extends Statify {
 		}
 
 		/** Skip tracking via Referrer check and Conditional_Tags. */
-		return ( self::check_referrer() || is_feed() || is_trackback() || is_robots()
-				 || is_preview() || is_user_logged_in() || is_404() || is_search()
+		return ( self::check_referrer() || is_trackback() || is_robots() || is_user_logged_in()
+			|| self::_is_internal()
 		);
+	}
+
+	/**
+	 * Rules to detect internal calls to skip tracking and not print code snippet.
+	 *
+	 * @since    1.7.0
+	 *
+	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
+	 */
+	private static function _is_internal() {
+		return is_feed() || is_preview() || is_404() || is_search();
 	}
 
 	/**
@@ -264,8 +275,8 @@ class Statify_Frontend extends Statify {
 			return;
 		}
 
-		/* Skip by rules */
-		if ( self::_skip_tracking() ) {
+		/* Skip by internal rules (#84) */
+		if ( self::_is_internal() ) {
 			return;
 		}
 


### PR DESCRIPTION
I cut the `_skip_tracking()` method in two parts to enable different checks for tracking itself and appending the JS snippet without duplicating code.

Common exclusions are feed, 404, search and preview. In any other case (bots, blacklisted referrer, logged-in users, ...) the snippet is appended to avoid building up a cached page without JS.