### PR TITLE
Fix regression from referrer sanitization

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -46,7 +46,7 @@ class Statify_Frontend extends Statify {
 
 			$referrer = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_URL );
 			if ( is_null( $referrer ) || false === $referrer ) {
-				$target = '';
+				$referrer = '';
 			}
 		} else {
 			return false;


### PR DESCRIPTION
Target has been reset if referrer isn't valid URL.
Regression from superglobal sanitization in v1.6.1

This leads to exclusion of all users without a valid referrer, if Javascript tracking is disabled. The bug has been reported in WP forums (German): https://wordpress.org/support/topic/statify-zahlt-nicht-mehr-nach-update/