### PR TITLE
Separate data from script tag and bulletproof JS

### DIFF
--- a/js/snippet.js
+++ b/js/snippet.js
@@ -1,8 +1,11 @@
-const statifyReq = new XMLHttpRequest();
-statifyReq.open(
-	'GET',
-	document.getElementById('statify-js-snippet').getAttribute('data-home-url')
-	+ '?statify_referrer=' + encodeURIComponent(document.referrer)
-	+ '&statify_target=' + encodeURIComponent(location.pathname + location.search)
-);
-statifyReq.send( null );
+try {
+	const statifyReq = new XMLHttpRequest();
+	statifyReq.open(
+		'GET',
+		document.getElementById('statify-js-snippet').getAttribute('data-home-url')
+		+ '?statify_referrer=' + encodeURIComponent(document.referrer)
+		+ '&statify_target=' + encodeURIComponent(location.pathname + location.search)
+	);
+	statifyReq.send(null);
+} catch (e) {
+}

--- a/views/js-snippet.php
+++ b/views/js-snippet.php
@@ -10,11 +10,12 @@
 class_exists( 'Statify' ) || exit; ?>
 
 	<!-- Stats by http://statify.de -->
-	<script
-		id="statify-js-snippet"
-		data-home-url="<?php echo esc_url( home_url( '/', 'relative' ) ); ?>"
-		type="text/javascript"
-		src="<?php echo esc_attr( plugins_url( 'js/snippet.js', STATIFY_FILE ) ); ?>">
+	<div id="statify-js-snippet"
+		 style="display:none"
+		 data-home-url="<?php echo esc_url( home_url( '/', 'relative' ) ); ?>">
+	</div>
+	<script type="text/javascript"
+			src="<?php echo esc_attr( plugins_url( 'js/snippet.js', STATIFY_FILE ) ); ?>">
 	</script>
 
 <?php /* Markup space */ ?>


### PR DESCRIPTION
This PR is a suggestion for #91.

First the `data-home-url` attribute is extracted into a hidden `<div>` tag to prevent issues with optimization plugins that remove the original `<script>` tag.

Additionally I added a try-catch around the actual script.
If the script is bundled in a single great JS file and fails for some reason, it should not mess up with any other functionality. Of course one could have added some nested `if(elem){}` calls to check whether the requested HTML element/attribute exist, but try-catch seems less code to write and basically does the same + catches XHR related exceptions if any.