### PR TITLE
Jump out instead of returning false when tracking is skipped

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -59,7 +59,7 @@ class Statify_Frontend extends Statify {
 
 		/* Check whether tracking should be skipped for this view. */
 		if ( self::_skip_tracking() ) {
-			return false;
+			return self::_jump_out( $is_snippet );
 		}
 
 		/* Global vars */


### PR DESCRIPTION
Hard coded false leads to full HTML parsing on snippet call, which not only is wasted computational time but reveals details about potential blacklists and configuration.

Doesn't really change any functionality, but prevents unnecessary site generation.