### PR TITLE
Refactor filter_input to filter_var for SERVER variables

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -37,14 +37,20 @@ class Statify_Frontend extends Statify {
 			$target   = urldecode( get_query_var( 'statify_target' ) );
 			$referrer = urldecode( get_query_var( 'statify_referrer' ) );
 		} elseif ( ! $use_snippet ) {
-			$target = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL );
+			$target   = filter_var(
+				( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '/' ),
+				FILTER_SANITIZE_URL
+			);
 			if ( is_null( $target ) || false === $target ) {
 				$target = '/';
 			} else {
 				$target = wp_unslash( $target );
 			}
 
-			$referrer = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_URL );
+			$referrer = filter_var(
+				( isset( $_SERVER['HTTP_REFERER'] ) ? wp_unslash( $_SERVER['HTTP_REFERER'] ) : '' ),
+				FILTER_SANITIZE_URL
+			);
 			if ( is_null( $referrer ) || false === $referrer ) {
 				$referrer = '';
 			}
@@ -153,7 +159,10 @@ class Statify_Frontend extends Statify {
 		}
 
 		// Skip tracking via User Agent.
-		$user_agent = filter_input( INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_SANITIZE_STRING );
+		$user_agent = filter_var(
+			( isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '' ),
+			FILTER_SANITIZE_STRING
+		);
 		if ( is_null( $user_agent )
 			|| false === $user_agent
 			|| ! preg_match( '/(?:Windows|Macintosh|Linux|iPhone|iPad)/', $user_agent ) ) {
@@ -193,7 +202,10 @@ class Statify_Frontend extends Statify {
 			return false;
 		}
 
-		$referrer = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_URL );
+		$referrer = filter_var(
+			( isset( $_SERVER['HTTP_REFERER'] ) ? wp_unslash( $_SERVER['HTTP_REFERER'] ) : '' ),
+			FILTER_SANITIZE_URL
+		);
 		if ( ! is_null( $referrer ) && false !== $referrer ) {
 			$referrer = wp_parse_url( $referrer, PHP_URL_HOST );
 		} else {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,6 +29,8 @@
         <exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />
         <exclude name="WordPress.VIP.DirectDatabaseQuery.SchemaChange" />
         <exclude name="WordPress.WP.PreparedSQL.NotPrepared" />
+        <!-- Sanitization of $_SERVER causes problems with some PHP implementations -->
+        <exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized"/>
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->


### PR DESCRIPTION
`filter_input()` seemingly returns `NULL` on `INPUT_SERVER` values for some PHP implementations. This is caused by the way, superglobal variables are injected, esp. in CGI instanes. There are even PHP 7.x versions out there affected by this issue. (Bug report, e.g. https://bugs.php.net/bug.php?id=49184)

Solution is to partially reverted a change from #85 and use `filter_var()` on the `$_SERVER['...']` value instead. Doesn't look really handy, but whitouht raising a notice for non-existing value and a the null coalescing operator unavailable in 5.x is provides about the same type safety.

Issue and hint originally reported here (German): https://wordpress.org/support/topic/bei-mir-auch-seit-update-keine-zahlung-mehr/