### PR TITLE
Correct check_referrer() for empty values

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -208,8 +208,6 @@ class Statify_Frontend extends Statify {
 		);
 		if ( ! is_null( $referrer ) && false !== $referrer ) {
 			$referrer = wp_parse_url( $referrer, PHP_URL_HOST );
-		} else {
-			$referrer = '';
 		}
 
 		// Return false if there is no referrer to check.

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -193,7 +193,7 @@ class Statify_Frontend extends Statify {
 	 * @since   2016-12-21
 	 * @version 2017-01-10
 	 *
-	 * @return  bool
+	 * @return  boolean TRUE of referrer matches blacklist entry and should thus be excluded.
 	 */
 	private static function check_referrer() {
 
@@ -212,18 +212,22 @@ class Statify_Frontend extends Statify {
 			$referrer = '';
 		}
 
+		// Return false if there is no referrer to check.
 		if ( empty( $referrer ) ) {
-			return true;
+			return false;
 		}
 
+		// Fallback for wp_parse_url() returning array instead of host only.
 		if ( is_array( $referrer ) && isset( $referrer['host'] ) ) {
 			$referrer = $referrer['host'];
 		}
 
+		// Return false if there still is no referrer to checj.
 		if ( ! is_string( $referrer ) ) {
 			return false;
 		}
 
+		// Finally compare referrer against the blacklist.
 		$blacklist = self::get_blacklist_keys();
 		foreach ( $blacklist as $item ) {
 			if ( strpos( $referrer, $item ) !== false ) {

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -210,11 +210,6 @@ class Statify_Frontend extends Statify {
 			$referrer = wp_parse_url( $referrer, PHP_URL_HOST );
 		}
 
-		// Return false if there is no referrer to check.
-		if ( empty( $referrer ) ) {
-			return false;
-		}
-
 		// Fallback for wp_parse_url() returning array instead of host only.
 		if ( is_array( $referrer ) && isset( $referrer['host'] ) ) {
 			$referrer = $referrer['host'];


### PR DESCRIPTION
This PR fixed the first part of #93.

The `Statify_Frontend::check_referrer()` method returned `true` on empty referrers and thus excluded these visitors from tracking, if the blacklist check is enabled. Changed this to return `false` and added some comments to the method to clearly state what is done there.

Additionaly, as @bueltge suggested, I removed the redundant else-branch of the referrer generation, as it does not make any difference if `null`, `false` or an empty string is passed to the following ~`empty()`~ `is_array()` and `is_string()` check.