### PR TITLE
Prepare release 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.3
+* Fix compatibility issue with some PHP implementations not populating `INPUT_SERVER`
+* Fix failing blacklist check for empty referrers
+* JS snippet call properly breaks page generation when tracking is skipped
+
 ## 1.6.2
 * Fix compatibility issues with JavaScript optimization plugins
 * Fix tracking issue if JavaScript tracking is disabled

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -140,7 +140,7 @@ class Statify_Frontend extends Statify {
 	 * Rules to skip the tracking
 	 *
 	 * @since    1.2.6
-	 * @version  2016-12-21
+	 * @version  1.6.3
 	 *
 	 * @hook     boolean  statify__skip_tracking
 	 * @see      https://wordpress.org/plugins/statify/
@@ -178,7 +178,7 @@ class Statify_Frontend extends Statify {
 	/**
 	 * Rules to detect internal calls to skip tracking and not print code snippet.
 	 *
-	 * @since    1.7.0
+	 * @since    1.6.1
 	 *
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */
@@ -190,8 +190,8 @@ class Statify_Frontend extends Statify {
 	 * Compare the referrer url to the blacklist data.
 	 * De/activate this feature via settings in the Dashboard widget.
 	 *
-	 * @since   2016-12-21
-	 * @version 2017-01-10
+	 * @since   1.5.0
+	 * @version 1.6.3
 	 *
 	 * @return  boolean TRUE of referrer matches blacklist entry and should thus be excluded.
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,11 @@ has to be added to the theme's `functions.php`. The condition has modified such 
 ## Changelog ##
 You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
 
+### 1.6.3
+* Fix compatibility issue with some PHP implementations not populating `INPUT_SERVER`
+* Fix failing blacklist check for empty referrers
+* JS snippet call properly breaks page generation when tracking is skipped
+
 ### 1.6.2
 * Fix compatibility issues with JavaScript optimization plugins
 * Fix tracking issue if JavaScript tracking is disabled
@@ -137,6 +142,13 @@ For the complete changelog, check out our [GitHub repository](https://github.com
 
 
 ## Upgrade Notice ##
+
+### 1.6.3 ###
+This bugfix release is recommended for all users.
+It fixes completely broken tracking with some PHP implementations. Sorry for that, we might owe you a couple of visitors.
+
+### 1.6.2 ###
+This bugfix release is recommended for all users.
 
 ### 1.6.1 ###
 This bugfix release is recommended for all users.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Requires at least: 4.7
 * Tested up to:      4.9
 * Requires PHP:      5.6
-* Stable tag:        1.6.2
+* Stable tag:        1.6.3
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/statify.php
+++ b/statify.php
@@ -7,7 +7,7 @@
  * Author URI:  https://pluginkollektiv.org
  * Plugin URI:  https://wordpress.org/plugins/statify/
  * License:     GPLv3 or later
- * Version:     1.6.2
+ * Version:     1.6.3
  *
  * @package WordPress
  */


### PR DESCRIPTION
As indicated, changelog and readme are updated with the latest merges, stable tag bumped to 1.6.3.

Fixed issues for this release: #94, #95, #96 (partially #93)

Additionaly some forgotten PHPdoc version tags have been updated and one futuristic 1.7.0 tag corrected to the actual release (1.6.1).

No code changed in this PR.