### PR TITLE
Restore PHP 5.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "statistics"
   ],
   "require": {
-    "php": "^5.6|^7",
+    "php": "^5.3|^7",
     "npm-asset/chartist": "^0.11.0",
     "npm-asset/chartist-plugin-tooltips": "^0.0.18"
   },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "statistics"
   ],
   "require": {
-    "php": "^5.3|^7",
+    "php": "^5.2|^7",
     "npm-asset/chartist": "^0.11.0",
     "npm-asset/chartist-plugin-tooltips": "^0.0.18"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "72294a3fff49e315b96a0abc3c5bc323",
+    "hash": "32413376f0785130657c0ae8482f5558",
+    "content-hash": "42b9efd959e1988cc61b4d90a32eac14",
     "packages": [
         {
             "name": "npm-asset/chartist",
@@ -107,7 +108,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2017-12-06 16:27:17"
         },
         {
             "name": "matthiasmullie/minify",
@@ -167,7 +168,7 @@
                 "minifier",
                 "minify"
             ],
-            "time": "2018-04-18T08:50:35+00:00"
+            "time": "2018-04-18 08:50:35"
         },
         {
             "name": "matthiasmullie/path-converter",
@@ -216,7 +217,7 @@
                 "paths",
                 "relative"
             ],
-            "time": "2018-02-02T11:30:10+00:00"
+            "time": "2018-02-02 11:30:10"
         },
         {
             "name": "slowprog/composer-copy-file",
@@ -263,7 +264,7 @@
             "keywords": [
                 "copy file"
             ],
-            "time": "2017-12-07T13:18:47+00:00"
+            "time": "2017-12-07 13:18:47"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -314,7 +315,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-02-20 21:35:23"
         },
         {
             "name": "wimg/php-compatibility",
@@ -366,7 +367,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-27T21:58:38+00:00"
+            "time": "2017-12-27 21:58:38"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -406,7 +407,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-02-16 01:57:48"
         }
     ],
     "aliases": [],
@@ -415,7 +416,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6|^7"
+        "php": "^5.3|^7"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "32413376f0785130657c0ae8482f5558",
-    "content-hash": "42b9efd959e1988cc61b4d90a32eac14",
+    "hash": "4fe6d7ea043ff6014c56a8a1145239c4",
+    "content-hash": "775564b6fe2fe58ba36196c59667e99c",
     "packages": [
         {
             "name": "npm-asset/chartist",
@@ -416,7 +416,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.3|^7"
+        "php": "^5.2|^7"
     },
     "platform-dev": []
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,6 +34,6 @@
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="5.3-"/>
+    <config name="testVersion" value="5.2-"/>
     <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,6 +34,6 @@
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="5.6-"/>
+    <config name="testVersion" value="5.3-"/>
     <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
 * Tested up to:      4.9
+* Requires PHP:      5.2
 * Stable tag:        1.6.3
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
 * Tested up to:      4.9
-* Requires PHP:      5.6
+* Requires PHP:      5.3
 * Stable tag:        1.6.3
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,6 @@
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
 * Tested up to:      4.9
-* Requires PHP:      5.3
 * Stable tag:        1.6.3
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html

--- a/statify.php
+++ b/statify.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 
 /*  Constants */
 define( 'STATIFY_FILE', __FILE__ );
-define( 'STATIFY_DIR', __DIR__ );
+define( 'STATIFY_DIR', dirname( __FILE__ ) );
 define( 'STATIFY_BASE', plugin_basename( __FILE__ ) );
 
 


### PR DESCRIPTION
In v1.5.0 we raised the minimum PHP requirement to 5.3.
In v1.5.3 (e1280a9 to be precise) we again raised the minimum PHP version to 5.6 - apparently for no reason whatsoever.

The code is still compatible with 5.3 today and with a single change, replacing a single use of `__DIR__` in the plugin's main file, 5.2 compatibility can be restored.

Of course I don't wanna encourage anybody to use historical software, but as recent tests have shown there are at least 5.4 and 5.5 users out there using Statify and we don't necessarily have to confuse them with pointless compatibility declarations....