### PR TITLE
Introduce settings page and more options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 * Introduced separate settinge page and reduced widget backview to widget settings only
+* Add options to track logged in users, feeds and search requests
 
 ## 1.6.3
 * Fix compatibility issue with some PHP implementations not populating `INPUT_SERVER`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+* Introduced separate settinge page and reduced widget backview to widget settings only
+
 ## 1.6.3
 * Fix compatibility issue with some PHP implementations not populating `INPUT_SERVER`
 * Fix failing blacklist check for empty referrers

--- a/inc/class-statify-backend.php
+++ b/inc/class-statify-backend.php
@@ -70,8 +70,8 @@ class Statify_Backend {
 					/* @lang  Disable language injection for Url query argument. */
 					'<a href="%s">%s</a>',
 					add_query_arg(
-						array( 'edit' => 'statify_dashboard#statify_dashboard' ),
-						admin_url( '/' )
+						array( 'page' => 'statify-settings' ),
+						admin_url( '/options-general.php' )
 					),
 					esc_html__( 'Settings', 'statify' )
 				),

--- a/inc/class-statify-backend.php
+++ b/inc/class-statify-backend.php
@@ -58,7 +58,7 @@ class Statify_Backend {
 	public static function add_action_link( $input ) {
 
 		// Rights?
-		if ( ! current_user_can( 'edit_dashboard' ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return $input;
 		}
 

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -183,7 +183,7 @@ class Statify_Dashboard extends Statify {
 		if ( ! empty( $_POST['statify'] ) ) {
 			check_admin_referer( 'statify-dashboard' );
 
-			self::_save_options();
+			self::_save_widget_options();
 		}
 
 		// Load view.
@@ -194,36 +194,35 @@ class Statify_Dashboard extends Statify {
 
 
 	/**
-	 * Save plugin options
+	 * Save dashboard widget options.
 	 *
 	 * @since    1.4.0
-	 * @version  2017-01-10
+	 * @sicnce   1.7.0 Renamed to _save_widget_options()
+	 *
+	 * @return void
 	 */
-	private static function _save_options() {
+	private static function _save_widget_options() {
 		// Check the nonce field from the dashboard form.
 		if ( ! check_admin_referer( 'statify-dashboard' ) ) {
 			return;
 		}
 
-		// Get numeric values from POST variables.
-		$options = array();
-		foreach ( array( 'days', 'limit' ) as $option_name ) {
-			$options[ $option_name ] = Statify::$_options[ $option_name ];
-			if ( isset( $_POST['statify'][ $option_name ] ) && (int) $_POST['statify'][ $option_name ] > 0 ) {
-				$options[ $option_name ] = (int) $_POST['statify'][ $option_name ];
-			}
+		// We only do a partial update, so initialize with current values.
+		$options = Statify::$_options;
+
+		// Parse numeric "limit" value.
+		if ( isset( $_POST['statify']['limit'] ) && (int) $_POST['statify']['limit'] > 0 ) {
+			$options['limit'] = (int) $_POST['statify']['limit'];
 		}
-		if ( (int) $options['limit'] > 100 ) {
+		if ( $options['limit'] > 100 ) {
 			$options['limit'] = 100;
 		}
 
-		// Get checkbox values from POST variables.
-		foreach ( array( 'today', 'snippet', 'blacklist' ) as $option_name ) {
-			if ( isset( $_POST['statify'][ $option_name ] ) && 1 === (int) $_POST['statify'][ $option_name ] ) {
-				$options[ $option_name ] = 1;
-			} else {
-				$options[ $option_name ] = 0;
-			}
+		// Parse "today" checkbox.
+		if ( isset( $_POST['statify']['today'] ) && 1 === (int) $_POST['statify']['today'] ) {
+			$options['today'] = 1;
+		} else {
+			$options['today'] = 0;
 		}
 
 		// Update values.

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -42,6 +42,9 @@ class Statify_Dashboard extends Statify {
 			return;
 		}
 
+		// Check if user can edit the widget.
+		$can_edit = apply_filters( 'statify__user_can_see_stats', current_user_can( 'edit_dashboard' ) );
+
 		// Load textdomain.
 		load_plugin_textdomain(
 			'statify',
@@ -57,7 +60,7 @@ class Statify_Dashboard extends Statify {
 			'statify_dashboard',
 			'Statify',
 			array( __CLASS__, 'print_frontview' ),
-			array( __CLASS__, 'print_backview' )
+			$can_edit ? array( __CLASS__, 'print_backview' ) : null
 		);
 
 		// Init CSS.

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -169,10 +169,23 @@ class Statify_Frontend extends Statify {
 			return true;
 		}
 
-		// Skip tracking via Referrer check and Conditional_Tags.
-		return ( self::check_referrer() || is_trackback() || is_robots() || is_user_logged_in()
-			|| self::_is_internal()
-		);
+		// Skip tracking via Referrer check.
+		if ( self::check_referrer() ) {
+			return true;
+		}
+
+		// Skip for trackbacks and robots.
+		if ( is_trackback() || is_robots() ) {
+			return true;
+		}
+
+		// Skip logged in users, if enabled.
+		if ( self::$_options['skip']['logged_in'] && is_user_logged_in() ) {
+			return true;
+		}
+
+		// Skip for "internal" requests.
+		return self::_is_internal();
 	}
 
 	/**
@@ -183,7 +196,18 @@ class Statify_Frontend extends Statify {
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */
 	private static function _is_internal() {
-		return is_feed() || is_preview() || is_404() || is_search();
+		// Skip for feed access, if enabled.
+		if ( self::$_options['skip']['feed'] && is_feed() ) {
+			return true;
+		}
+
+		// Skip for preview and 404 calls.
+		if ( is_preview() || is_404() ) {
+			return true;
+		}
+
+		// Skip for seach requests, if enabled.
+		return self::$_options['skip']['search'] && is_search();
 	}
 
 	/**

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -136,7 +136,7 @@ class Statify_Settings {
 	public static function options_snippet() {
 		?>
 		<input id="statify-snippet" type="checkbox" name="statify[snippet]" value="1" <?php checked( Statify::$_options['snippet'], 1 ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'This option is strongly recommended if caching is in use.', 'statify' ); ?></p>
 		<?php
@@ -175,7 +175,7 @@ class Statify_Settings {
 	public static function options_today() {
 		?>
 		<input  id="statify-today" type="checkbox" name="statify[today]" value="1" <?php checked( Statify::$_options['today'], 1 ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
 		<?php
 	}
 
@@ -200,7 +200,7 @@ class Statify_Settings {
 	public static function options_skip_blacklist() {
 		?>
 		<input id="statify-skip-referrer" type="checkbox" name="statify[blacklist]" value="1"<?php checked( Statify::$_options['blacklist'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views with referrers listed in the comment blacklist', 'statify' ); ?>.</p>
 		<?php
@@ -214,7 +214,7 @@ class Statify_Settings {
 	public static function options_skip_logged_in() {
 		?>
 		<input id="statify-skip-logged_in" type="checkbox" name="statify[skip][logged_in]" value="1"<?php checked( Statify::$_options['skip']['logged_in'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views of logged-in users from tracking.', 'statify' ); ?></p>
 		<?php
@@ -228,7 +228,7 @@ class Statify_Settings {
 	public static function options_skip_feed() {
 		?>
 		<input id="statify-skip-feed" type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes all requests to feeds (RSS, Atom, etc.) from tracking.', 'statify' ); ?></p>
 		<?php
@@ -242,7 +242,7 @@ class Statify_Settings {
 	public static function options_skip_search() {
 		?>
 		<input id="statify-skip-search" type="checkbox" name="statify[skip][search]" value="1"<?php checked( Statify::$_options['skip']['search'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes search result pages from tracking.', 'statify' ); ?></p>
 		<?php

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -227,7 +227,7 @@ class Statify_Settings {
 	 */
 	public static function options_skip_feed() {
 		?>
-		<input id="statify-skip-feed" type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>
+		<input id="statify-skip-feed" type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes all requests to feeds (RSS, Atom, etc.) from tracking.', 'statify' ); ?></p>

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -38,14 +38,16 @@ class Statify_Settings {
 			__( 'Period of data saving', 'statify' ),
 			array( __CLASS__, 'options_days' ),
 			'statify',
-			'statify-global'
+			'statify-global',
+			array( 'label_for' => 'statify-days' )
 		);
 		add_settings_field(
 			'statify-snippet',
 			__( 'Tracking via JavaScript', 'statify' ),
 			array( __CLASS__, 'options_snippet' ),
 			'statify',
-			'statify-global'
+			'statify-global',
+			array( 'label_for' => 'statify-snippet' )
 		);
 
 		// Dashboard widget settings.
@@ -60,14 +62,16 @@ class Statify_Settings {
 			__( 'Number of entries in top lists', 'statify' ),
 			array( __CLASS__, 'options_limit' ),
 			'statify',
-			'statify-dashboard'
+			'statify-dashboard',
+			array( 'label_for' => 'statify-limit' )
 		);
 		add_settings_field(
 			'statify-today',
 			__( 'Top lists only for today', 'statify' ),
 			array( __CLASS__, 'options_today' ),
 			'statify',
-			'statify-dashboard'
+			'statify-dashboard',
+			array( 'label_for' => 'statify-today' )
 		);
 
 		// Exclusion settings.
@@ -82,28 +86,32 @@ class Statify_Settings {
 			__( 'Blacklisted referrers', 'statify' ),
 			array( __CLASS__, 'options_skip_blacklist' ),
 			'statify',
-			'statify-skip'
+			'statify-skip',
+			array( 'label_for' => 'statify-skip-referrer' )
 		);
 		add_settings_field(
 			'statify-skip-logged_in',
 			__( 'Logged in users', 'statify' ),
 			array( __CLASS__, 'options_skip_logged_in' ),
 			'statify',
-			'statify-skip'
+			'statify-skip',
+			array( 'label_for' => 'statify-skip-logged_in' )
 		);
 		add_settings_field(
 			'statify-skip-feed',
 			__( 'Feed', 'statify' ),
 			array( __CLASS__, 'options_skip_feed' ),
 			'statify',
-			'statify-skip'
+			'statify-skip',
+			array( 'label_for' => 'statify-skip-feed' )
 		);
 		add_settings_field(
 			'statify-skip-search',
 			__( 'Search requests', 'statify' ),
 			array( __CLASS__, 'options_skip_search' ),
 			'statify',
-			'statify-skip'
+			'statify-skip',
+			array( 'label_for' => 'statify-skip-search' )
 		);
 	}
 
@@ -115,7 +123,7 @@ class Statify_Settings {
 	public static function options_days() {
 		?>
 		<input id="statify-days" name="statify[days]" type="number" min="1" value="<?php echo esc_attr( Statify::$_options['days'] ); ?>">
-		<label for="statify-days"><?php esc_html_e( 'days', 'statify' ); ?></label>
+		<?php esc_html_e( 'days', 'statify' ); ?>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: 14)
 		<?php
 	}
@@ -127,8 +135,7 @@ class Statify_Settings {
 	 */
 	public static function options_snippet() {
 		?>
-		<input type="checkbox" name="statify[snippet]" id="statify_snippet" value="1" <?php checked( Statify::$_options['snippet'], 1 ); ?>
-			title="<?php esc_attr_e( 'Tracking via JavaScript', 'statify' ); ?>">
+		<input id="statify-snippet" type="checkbox" name="statify[snippet]" value="1" <?php checked( Statify::$_options['snippet'], 1 ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'This option is strongly recommended if caching is in use.', 'statify' ); ?></p>
@@ -155,8 +162,7 @@ class Statify_Settings {
 	 */
 	public static function options_limit() {
 		?>
-		<input id="statify-limit" name="statify[limit]" type="number" min="1" max="100" value="<?php echo esc_attr( Statify::$_options['limit'] ); ?>"
-			title="<?php esc_attr_e( 'Number of entries in top lists', 'statify' ); ?>">
+		<input id="statify-limit" name="statify[limit]" type="number" min="1" max="100" value="<?php echo esc_attr( Statify::$_options['limit'] ); ?>">
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: 3)
 		<?php
 	}
@@ -168,8 +174,7 @@ class Statify_Settings {
 	 */
 	public static function options_today() {
 		?>
-		<input  id="statify-today" type="checkbox" name="statify[today]" value="1" <?php checked( Statify::$_options['today'], 1 ); ?>
-			title="<?php esc_attr_e( 'Entries in top lists only for today', 'statify' ); ?>">
+		<input  id="statify-today" type="checkbox" name="statify[today]" value="1" <?php checked( Statify::$_options['today'], 1 ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
 		<?php
 	}
@@ -194,8 +199,7 @@ class Statify_Settings {
 	 */
 	public static function options_skip_blacklist() {
 		?>
-		<input type="checkbox" name="statify[blacklist]" value="1"<?php checked( Statify::$_options['blacklist'] ); ?>
-			title="<?php esc_attr_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>">
+		<input id="statify-skip-referrer" type="checkbox" name="statify[blacklist]" value="1"<?php checked( Statify::$_options['blacklist'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views with referrers listed in the comment blacklist', 'statify' ); ?>.</p>
@@ -209,8 +213,7 @@ class Statify_Settings {
 	 */
 	public static function options_skip_logged_in() {
 		?>
-		<input type="checkbox" name="statify[skip][logged_in]" value="1"<?php checked( Statify::$_options['skip']['logged_in'] ); ?>
-			title="<?php esc_attr_e( 'Skip tracking for logged in users', 'statify' ); ?>">
+		<input id="statify-skip-logged_in" type="checkbox" name="statify[skip][logged_in]" value="1"<?php checked( Statify::$_options['skip']['logged_in'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views of logged-in users from tracking.', 'statify' ); ?></p>
@@ -224,8 +227,7 @@ class Statify_Settings {
 	 */
 	public static function options_skip_feed() {
 		?>
-		<input type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>
-			title="<?php esc_attr_e( 'Skip tracking for feed access', 'statify' ); ?>">
+		<input id="statify-skip-feed" type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes all requests to feeds (RSS, Atom, etc.) from tracking.', 'statify' ); ?></p>
@@ -239,8 +241,7 @@ class Statify_Settings {
 	 */
 	public static function options_skip_search() {
 		?>
-		<input type="checkbox" name="statify[skip][search]" value="1"<?php checked( Statify::$_options['skip']['search'] ); ?>
-			title="<?php esc_attr_e( 'Skip tracking for search requests', 'statify' ); ?>">
+		<input id="statify-skip-search" type="checkbox" name="statify[skip][search]" value="1"<?php checked( Statify::$_options['skip']['search'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes search result pages from tracking.', 'statify' ); ?></p>

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Statify: Statify_Settings class
+ *
+ * This file contains the plugin's settings capabilities.
+ *
+ * @package   Statify
+ * @since     1.7
+ */
+
+// Quit ic accessed directly..
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Statify_Settings
+ *
+ * @since 1.7
+ */
+class Statify_Settings {
+
+	/**
+	 * Registers all options using the WP Settings API.
+	 *
+	 * @return void
+	 */
+	public static function register_settings() {
+		register_setting( 'statify', 'statify', array( __CLASS__, 'sanitize_options' ) );
+
+		// Global settings.
+		add_settings_section(
+			'statify-global',
+			__( 'Global settings', 'statif' ),
+			null,
+			'statify'
+		);
+		add_settings_field(
+			'statify-days',
+			__( 'Period of data saving', 'statify' ),
+			array( __CLASS__, 'options_days' ),
+			'statify',
+			'statify-global'
+		);
+		add_settings_field(
+			'statify-snippet',
+			__( 'Tracking via JavaScript', 'statify' ),
+			array( __CLASS__, 'options_snippet' ),
+			'statify',
+			'statify-global'
+		);
+
+		// Dashboard widget settings.
+		add_settings_section(
+			'statify-dashboard',
+			__( 'Dashboard Widget', 'statif' ),
+			array( __CLASS__, 'header_dashboard' ),
+			'statify'
+		);
+		add_settings_field(
+			'statify-limit',
+			__( 'Number of entries in top lists', 'statify' ),
+			array( __CLASS__, 'options_limit' ),
+			'statify',
+			'statify-dashboard'
+		);
+		add_settings_field(
+			'statify-today',
+			__( 'Top lists only for today', 'statify' ),
+			array( __CLASS__, 'options_today' ),
+			'statify',
+			'statify-dashboard'
+		);
+
+		// Exclusion settings.
+		add_settings_section(
+			'statify-skip',
+			__( 'Skip tracking for ...', 'statify' ),
+			array( __CLASS__, 'header_skip' ),
+			'statify'
+		);
+		add_settings_field(
+			'statify-skip-referrer',
+			__( 'Blacklisted referrers', 'statify' ),
+			array( __CLASS__, 'options_skip_blacklist' ),
+			'statify',
+			'statify-skip'
+		);
+	}
+
+	/**
+	 * Option for data collection period.
+	 *
+	 * @return void
+	 */
+	public static function options_days() {
+		?>
+		<input id="statify-days" name="statify[days]" type="number" min="1" value="<?php echo esc_attr( Statify::$_options['days'] ); ?>">
+		<label for="statify-days"><?php esc_html_e( 'days', 'statify' ); ?></label>
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: 14)
+		<?php
+	}
+
+	/**
+	 * Option for tracking via JS.
+	 *
+	 * @return void
+	 */
+	public static function options_snippet() {
+		?>
+		<input type="checkbox" name="statify[snippet]" id="statify_snippet" value="1" <?php checked( Statify::$_options['snippet'], 1 ); ?>
+			title="<?php esc_attr_e( 'Tracking via JavaScript', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
+		<br>
+		<p class="description"><?php esc_html_e( 'This option is recommended if caching is in use.', 'statify' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Section header for "Dashboard Widget" section.
+	 *
+	 * @return void
+	 */
+	public static function header_dashboard() {
+		?>
+		<p>
+			<?php esc_html_e( 'The following options affect the admin dashboard widget.', 'statif' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Option for number of entries in top lists.
+	 *
+	 * @return void
+	 */
+	public static function options_limit() {
+		?>
+		<input id="statify-limit" name="statify[limit]" type="number" min="1" max="100" value="<?php echo esc_attr( Statify::$_options['limit'] ); ?>"
+			title="<?php esc_attr_e( 'Number of entries in top lists', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: 3)
+		<?php
+	}
+
+	/**
+	 * Option for number of entries in top lists.
+	 *
+	 * @return void
+	 */
+	public static function options_today() {
+		?>
+		<input  id="statify-today" type="checkbox" name="statify[today]" value="1" <?php checked( Statify::$_options['today'], 1 ); ?>
+			title="<?php esc_attr_e( 'Entries in top lists only for today', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
+		<?php
+	}
+
+	/**
+	 * Section header for "Skip tracking for..." section.
+	 *
+	 * @return void
+	 */
+	public static function header_skip() {
+		?>
+		<p>
+			<?php
+			echo wp_kses( __( 'The following options define cases in which a visit will <strong>not</strong> be tracked.', 'statify' ), array( 'strong' => array() ) );
+			?>
+
+		</p>
+		<?php
+	}
+
+	/**
+	 * Option to skip tracking for blacklisted referrers.
+	 *
+	 * @return void
+	 */
+	public static function options_skip_blacklist() {
+		?>
+		<input type="checkbox" name="statify[blacklist]" value="1"<?php checked( Statify::$_options['blacklist'] ); ?>
+			title="<?php esc_attr_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
+		<br>
+		<p class="description"><?php esc_html_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>.</p>
+		<?php
+	}
+
+	/**
+	 * Validate and sanitize submitted options.
+	 *
+	 * @param array $options Original options.
+	 *
+	 * @return array Validated and sanitized options.
+	 */
+	public static function sanitize_options( $options ) {
+
+		// Sanitize numeric values.
+		$res = array();
+		foreach ( array( 'days', 'limit' ) as $o ) {
+			$res[ $o ] = Statify::$_options[ $o ];
+			if ( isset( $options[ $o ] ) && (int) $options[ $o ] > 0 ) {
+				$res[ $o ] = (int) $options[ $o ];
+			}
+		}
+		if ( $res['limit'] > 100 ) {
+			$res['limit'] = 100;
+		}
+
+		// Get checkbox values from POST variables.
+		foreach ( array( 'today', 'snippet', 'blacklist' ) as $o ) {
+			if ( isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ) {
+				$res[ $o ] = 1;
+			} else {
+				$res[ $o ] = 0;
+			}
+		}
+
+		return $res;
+	}
+
+	/**
+	 * Creates a menu entry in the settings menu.
+	 *
+	 * @return void
+	 */
+	public static function add_admin_menu() {
+		add_options_page(
+			__( 'Statify', 'wp-calendar' ),
+			__( 'Statify', 'wp-calendar' ),
+			'manage_options',
+			'statify-settings',
+			array( __CLASS__, 'create_settings_page' )
+		);
+	}
+
+	/**
+	 * Creates the settings pages.
+	 *
+	 * @return void
+	 */
+	public static function create_settings_page() {
+		?>
+
+		<div class="wrap" id="cachify_settings">
+			<h1><?php esc_html_e( 'Statify Settings', 'wp-calendar' ); ?></h1>
+
+			<form id="staify-settings" method="post" action="options.php">
+				<?php
+				settings_fields( 'statify' );
+				do_settings_sections( 'statify' );
+				submit_button();
+				?>
+			</form>
+		</div>
+
+		<?php
+	}
+
+}

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -84,6 +84,27 @@ class Statify_Settings {
 			'statify',
 			'statify-skip'
 		);
+		add_settings_field(
+			'statify-skip-logged_in',
+			__( 'Logged in users', 'statify' ),
+			array( __CLASS__, 'options_skip_logged_in' ),
+			'statify',
+			'statify-skip'
+		);
+		add_settings_field(
+			'statify-skip-feed',
+			__( 'Feed access', 'statify' ),
+			array( __CLASS__, 'options_skip_feed' ),
+			'statify',
+			'statify-skip'
+		);
+		add_settings_field(
+			'statify-skip-search',
+			__( 'Search requests', 'statify' ),
+			array( __CLASS__, 'options_skip_search' ),
+			'statify',
+			'statify-skip'
+		);
 	}
 
 	/**
@@ -163,6 +184,7 @@ class Statify_Settings {
 		<p>
 			<?php
 			echo wp_kses( __( 'The following options define cases in which a visit will <strong>not</strong> be tracked.', 'statify' ), array( 'strong' => array() ) );
+			esc_html_e( 'The conditions are otherwise process in the given order.', 'statify' );
 			?>
 
 		</p>
@@ -181,6 +203,51 @@ class Statify_Settings {
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>.</p>
+		<?php
+	}
+
+	/**
+	 * Option to skip tracking for logged in uses.
+	 *
+	 * @return void
+	 */
+	public static function options_skip_logged_in() {
+		?>
+		<input type="checkbox" name="statify[skip][logged_in]" value="1"<?php checked( Statify::$_options['skip']['logged_in'] ); ?>
+			title="<?php esc_attr_e( 'Skip tracking for logged in users', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
+		<br>
+		<p class="description"><?php esc_html_e( 'This option affects registered users that are currently logged in.', 'statify' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Option to skip tracking for feed access.
+	 *
+	 * @return void
+	 */
+	public static function options_skip_feed() {
+		?>
+		<input type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>
+			title="<?php esc_attr_e( 'Skip tracking for feed access', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
+		<br>
+		<p class="description"><?php esc_html_e( 'If selected, requests to feed (RSS, Atom, etc.) are not tracked.', 'statify' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Option to skip tracking for search requests.
+	 *
+	 * @return void
+	 */
+	public static function options_skip_search() {
+		?>
+		<input type="checkbox" name="statify[skip][search]" value="1"<?php checked( Statify::$_options['skip']['search'] ); ?>
+			title="<?php esc_attr_e( 'Skip tracking for search requests', 'statify' ); ?>">
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
+		<br>
+		<p class="description"><?php esc_html_e( 'Define if visits on search pages should be excluded.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -205,13 +272,12 @@ class Statify_Settings {
 			$res['limit'] = 100;
 		}
 
-		// Get checkbox values from POST variables.
+		// Get checkbox values.
 		foreach ( array( 'today', 'snippet', 'blacklist' ) as $o ) {
-			if ( isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ) {
-				$res[ $o ] = 1;
-			} else {
-				$res[ $o ] = 0;
-			}
+			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
+		}
+		foreach ( array( 'logged_in', 'feed', 'search' ) as $o ) {
+			$res['skip'][ $o ] = isset( $options['skip'][ $o ] ) && 1 === (int) $options['skip'][ $o ] ? 1 : 0;
 		}
 
 		return $res;

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -29,7 +29,7 @@ class Statify_Settings {
 		// Global settings.
 		add_settings_section(
 			'statify-global',
-			__( 'Global settings', 'statif' ),
+			__( 'Global settings', 'statify' ),
 			null,
 			'statify'
 		);
@@ -51,7 +51,7 @@ class Statify_Settings {
 		// Dashboard widget settings.
 		add_settings_section(
 			'statify-dashboard',
-			__( 'Dashboard Widget', 'statif' ),
+			__( 'Dashboard Widget', 'statify' ),
 			array( __CLASS__, 'header_dashboard' ),
 			'statify'
 		);
@@ -93,7 +93,7 @@ class Statify_Settings {
 		);
 		add_settings_field(
 			'statify-skip-feed',
-			__( 'Feed access', 'statify' ),
+			__( 'Feed', 'statify' ),
 			array( __CLASS__, 'options_skip_feed' ),
 			'statify',
 			'statify-skip'
@@ -131,7 +131,7 @@ class Statify_Settings {
 			title="<?php esc_attr_e( 'Tracking via JavaScript', 'statify' ); ?>">
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
 		<br>
-		<p class="description"><?php esc_html_e( 'This option is recommended if caching is in use.', 'statify' ); ?></p>
+		<p class="description"><?php esc_html_e( 'This option is strongly recommended if caching is in use.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -143,7 +143,7 @@ class Statify_Settings {
 	public static function header_dashboard() {
 		?>
 		<p>
-			<?php esc_html_e( 'The following options affect the admin dashboard widget.', 'statif' ); ?>
+			<?php esc_html_e( 'The following options affect the admin dashboard widget.', 'statify' ); ?>
 		</p>
 		<?php
 	}
@@ -182,11 +182,7 @@ class Statify_Settings {
 	public static function header_skip() {
 		?>
 		<p>
-			<?php
-			echo wp_kses( __( 'The following options define cases in which a visit will <strong>not</strong> be tracked.', 'statify' ), array( 'strong' => array() ) );
-			esc_html_e( 'The conditions are otherwise process in the given order.', 'statify' );
-			?>
-
+			<?php echo wp_kses( __( 'The following options define cases in which a view will <strong>not</strong> be tracked.', 'statify' ), array( 'strong' => array() ) ); ?>
 		</p>
 		<?php
 	}
@@ -202,7 +198,7 @@ class Statify_Settings {
 			title="<?php esc_attr_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>">
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No' ); ?>)
 		<br>
-		<p class="description"><?php esc_html_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>.</p>
+		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views with referrers listed in the comment blacklist', 'statify' ); ?>.</p>
 		<?php
 	}
 
@@ -217,7 +213,7 @@ class Statify_Settings {
 			title="<?php esc_attr_e( 'Skip tracking for logged in users', 'statify' ); ?>">
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
-		<p class="description"><?php esc_html_e( 'This option affects registered users that are currently logged in.', 'statify' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views of logged-in users from tracking.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -232,7 +228,7 @@ class Statify_Settings {
 			title="<?php esc_attr_e( 'Skip tracking for feed access', 'statify' ); ?>">
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
-		<p class="description"><?php esc_html_e( 'If selected, requests to feed (RSS, Atom, etc.) are not tracked.', 'statify' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Enabling this option excludes all requests to feeds (RSS, Atom, etc.) from tracking.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -247,7 +243,7 @@ class Statify_Settings {
 			title="<?php esc_attr_e( 'Skip tracking for search requests', 'statify' ); ?>">
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes' ); ?>)
 		<br>
-		<p class="description"><?php esc_html_e( 'Define if visits on search pages should be excluded.', 'statify' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Enabling this option excludes search result pages from tracking.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -290,8 +286,8 @@ class Statify_Settings {
 	 */
 	public static function add_admin_menu() {
 		add_options_page(
-			__( 'Statify', 'wp-calendar' ),
-			__( 'Statify', 'wp-calendar' ),
+			__( 'Statify', 'statify' ),
+			__( 'Statify', 'statify' ),
 			'manage_options',
 			'statify-settings',
 			array( __CLASS__, 'create_settings_page' )
@@ -306,10 +302,10 @@ class Statify_Settings {
 	public static function create_settings_page() {
 		?>
 
-		<div class="wrap" id="cachify_settings">
-			<h1><?php esc_html_e( 'Statify Settings', 'wp-calendar' ); ?></h1>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Statify Settings', 'statify' ); ?></h1>
 
-			<form id="staify-settings" method="post" action="options.php">
+			<form id="statify-settings" method="post" action="options.php">
 				<?php
 				settings_fields( 'statify' );
 				do_settings_sections( 'statify' );

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -74,6 +74,8 @@ class Statify {
 			add_action( 'wp_dashboard_setup', array( 'Statify_Dashboard', 'init' ) );
 			add_filter( 'plugin_row_meta', array( 'Statify_Backend', 'add_meta_link' ), 10, 2 );
 			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify_Backend', 'add_action_link' ) );
+			add_action( 'admin_init', array( 'Statify_Settings', 'register_settings' ) );
+			add_action( 'admin_menu', array( 'Statify_Settings', 'add_admin_menu' ) );
 		} else {    // Frontend.
 			add_action( 'template_redirect', array( 'Statify_Frontend', 'track_visit' ) );
 			add_filter( 'query_vars', array( 'Statify_Frontend', 'query_vars' ) );

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -61,6 +61,11 @@ class Statify {
 				'today'     => 0,
 				'snippet'   => 0,
 				'blacklist' => 0,
+				'skip'      => array(
+					'logged_in' => 1,
+					'feed'      => 1,
+					'search'    => 1,
+				),
 			)
 		);
 

--- a/statify.php
+++ b/statify.php
@@ -71,6 +71,7 @@ function statify_autoload( $class ) {
 		'Statify_Install',
 		'Statify_Uninstall',
 		'Statify_Deactivate',
+		'Statify_Settings',
 		'Statify_Table',
 		'Statify_XMLRPC',
 		'Statify_Cron',

--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -10,6 +10,7 @@
 // Quit if accessed outside WP context.
 class_exists( 'Statify' ) || exit; ?>
 
+<?php if ( current_user_can( 'manage_options' ) ) : ?>
 <p class="meta-links">
 	<a href="<?php echo esc_attr( add_query_arg( array( 'page' => 'statify-settings' ), admin_url( '/options-general.php' ) ) ); ?>"
 		title="<?php esc_attr_e( 'Open full settings page', 'statify' ); ?>">
@@ -18,6 +19,7 @@ class_exists( 'Statify' ) || exit; ?>
 </p>
 
 <br>
+<?php endif; ?>
 
 <h3><?php esc_html_e( 'Widget Settings', 'statify' ); ?></h3>
 <fieldset>

--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -10,13 +10,17 @@
 // Quit if accessed outside WP context.
 class_exists( 'Statify' ) || exit; ?>
 
+<p class="meta-links">
+	<a href="<?php echo esc_attr( add_query_arg( array( 'page' => 'statify-settings' ), admin_url( '/options-general.php' ) ) ); ?>"
+		title="<?php esc_attr_e( 'Open full settings page', 'statify' ); ?>">
+		<span class="dashicons dashicons-admin-generic"></span>
+		<?php esc_html_e( 'All Settings', 'statify' ); ?></a>
+</p>
+
+<br>
+
+<h3><?php esc_html_e( 'Widget Settings', 'statify' ); ?></h3>
 <fieldset>
-	<label for="statify_days">
-		<input name="statify[days]" id="statify_days" type="number" min="1"
-			   value="<?php echo esc_attr( Statify::$_options['days'] ); ?>">
-		<?php esc_html_e( 'days', 'statify' ); ?> -
-		<?php esc_html_e( 'Period of data saving', 'statify' ); ?>
-	</label>
 	<label for="statify_limit">
 		<input name="statify[limit]" id="statify_limit" type="number" min="1" max="100"
 			   value="<?php echo esc_attr( Statify::$_options['limit'] ); ?>">
@@ -25,15 +29,6 @@ class_exists( 'Statify' ) || exit; ?>
 	<label for="statify_today">
 		<input type="checkbox" name="statify[today]" id="statify_today" value="1" <?php checked( Statify::$_options['today'], 1 ); ?> />
 		<?php esc_html_e( 'Entries in top lists only for today', 'statify' ); ?>
-	</label>
-	<label for="statify_snippet">
-		<input type="checkbox" name="statify[snippet]" id="statify_snippet" value="1" <?php checked( Statify::$_options['snippet'], 1 ); ?> />
-		<?php esc_html_e( 'Page tracking via JavaScript', 'statify' ); ?>
-		<small>(<?php esc_html_e( 'recommended if caching is in use', 'statify' ); ?>)</small>
-	</label>
-	<label for="statify_blacklist">
-		<input type="checkbox" name="statify[blacklist]" id="statify_blacklist" value="1" <?php checked( Statify::$_options['blacklist'], 1 ); ?> />
-		<?php esc_html_e( 'Skip tracking for referrers listed in the comment blacklist', 'statify' ); ?>
 	</label>
 </fieldset>
 <?php wp_nonce_field( 'statify-dashboard' ); ?>


### PR DESCRIPTION
This PR covers multiple issues and improvements. Feel free to edit or add.

Most significant change is the introduction of a new settings page. The widget backview is reduced to the two widget-related options (about top lists). I added a link to jump directly to the new page to not annoy existing users that are used to the old config panel.

Second I introduced three new checkboxes to control the `skip_tracking` behavior. I added the existing blacklist option to this group alongside with "logged in users", "feed" and "search". This partially covers #103, however the remaining options are not controllable yet. Might be combined with @2ndkauboy's solution to allow total control for pro users.
Especially the user agent filter with the RegEx might be suitable to configure here, but this is more of and advanced feature and not that easy to understand.

With the new page, the role filter (#106) can be integrated smoothly.
PR #72 is somewhat obsoleted or has to be adapted to the new method.

Finally two screenshots of the results:
![statify_106_screenshot2](https://user-images.githubusercontent.com/12963621/46407169-3bb53100-c70e-11e8-83cc-a526e4be20b2.png)
![statify_106_screenshot1](https://user-images.githubusercontent.com/12963621/46407168-39eb6d80-c70e-11e8-8de8-256cf23207c2.png)