### PR TITLE
revert options for feed and search tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 * Introduced separate settinge page and reduced widget backview to widget settings only
-* Add options to track logged in users, feeds and search requests
+* Add options to track logged in users
 * Add option to show total visits
 * Refactored JavaScript tracking to use WP AJAX
 * Updated Chartist JS library for dashboard widget

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -246,18 +246,8 @@ class Statify_Frontend extends Statify {
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */
 	private static function _is_internal() {
-		// Skip for feed access, if enabled.
-		if ( self::$_options['skip']['feed'] && is_feed() ) {
-			return true;
-		}
-
-		// Skip for preview and 404 calls.
-		if ( is_preview() || is_404() ) {
-			return true;
-		}
-
-		// Skip for seach requests, if enabled.
-		return self::$_options['skip']['search'] && is_search();
+		// Skip for preview, 404 calls, feed and search access.
+		return is_preview() || is_404() || is_feed() || is_search();
 	}
 
 	/**

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -113,22 +113,6 @@ class Statify_Settings {
 			'statify-skip',
 			array( 'label_for' => 'statify-skip-logged_in' )
 		);
-		add_settings_field(
-			'statify-skip-feed',
-			__( 'Feed', 'statify' ),
-			array( __CLASS__, 'options_skip_feed' ),
-			'statify',
-			'statify-skip',
-			array( 'label_for' => 'statify-skip-feed' )
-		);
-		add_settings_field(
-			'statify-skip-search',
-			__( 'Search requests', 'statify' ),
-			array( __CLASS__, 'options_skip_search' ),
-			'statify',
-			'statify-skip',
-			array( 'label_for' => 'statify-skip-search' )
-		);
 	}
 
 	/**
@@ -262,34 +246,6 @@ class Statify_Settings {
 	}
 
 	/**
-	 * Option to skip tracking for feed access.
-	 *
-	 * @return void
-	 */
-	public static function options_skip_feed() {
-		?>
-		<input id="statify-skip-feed" type="checkbox" name="statify[skip][feed]" value="1"<?php checked( Statify::$_options['skip']['feed'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
-		<br>
-		<p class="description"><?php esc_html_e( 'Enabling this option excludes all requests to feeds (RSS, Atom, etc.) from tracking.', 'statify' ); ?></p>
-		<?php
-	}
-
-	/**
-	 * Option to skip tracking for search requests.
-	 *
-	 * @return void
-	 */
-	public static function options_skip_search() {
-		?>
-		<input id="statify-skip-search" type="checkbox" name="statify[skip][search]" value="1"<?php checked( Statify::$_options['skip']['search'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
-		<br>
-		<p class="description"><?php esc_html_e( 'Enabling this option excludes search result pages from tracking.', 'statify' ); ?></p>
-		<?php
-	}
-
-	/**
 	 * Validate and sanitize submitted options.
 	 *
 	 * @param array $options Original options.
@@ -314,9 +270,7 @@ class Statify_Settings {
 		foreach ( array( 'today', 'snippet', 'blacklist', 'show_totals' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
-		foreach ( array( 'logged_in', 'feed', 'search' ) as $o ) {
-			$res['skip'][ $o ] = isset( $options['skip'][ $o ] ) && 1 === (int) $options['skip'][ $o ] ? 1 : 0;
-		}
+		$res['skip']['logged_in'] = isset( $options['skip']['logged_in'] ) && 1 === (int) $options['skip']['logged_in'] ? 1 : 0;
 
 		return $res;
 	}

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -65,8 +65,6 @@ class Statify {
 				'show_totals' => 0,
 				'skip'        => array(
 					'logged_in' => 1,
-					'feed'      => 1,
-					'search'    => 1,
 				),
 			)
 		);


### PR DESCRIPTION
Closes #137 and closes #138.

This PR partially reverts changes from #111, namely the options to not skip tracking for _feed_ and _search_ requests.

Feed tracking does not work with Javascript tracking and even if we introduces a "hybrid" model, i.e. feed access is tracked the classical way, it wouldn't work with caching.
Search access works in this context, but does not yield the expected results.

Removed both options for not to get 1.7.0 done. Left structures intact, s.t. we can reintroduce either of them in future releases after rethinking the implementation.