### PR TITLE
refactor static initialization method

### DIFF
--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -26,24 +26,32 @@ class Statify {
 	 */
 	public static $_options;
 
+	/**
+	 * Class constructor
+	 *
+	 * @since      0.1.0
+	 * @deprecated As of 1.7 use static method init() to initialize the plugin.
+	 */
+	public function __construct() {
+		self::init();
+	}
 
 	/**
 	 * Class self initialize.
 	 *
-	 * @since    0.1.0
-	 * @version  0.1.0
+	 * @since      0.1.0
+	 * @deprecated As of 1.7 use init() to initialize the plugin.
 	 */
 	public static function instance() {
-		new self();
+		self::init();
 	}
 
 	/**
-	 * Class constructor
+	 * Plugin initialization.
 	 *
-	 * @since    0.1.0
-	 * @version  2017-01-10
+	 * @since    1.7 Replaces previously used instance() and __construct().
 	 */
-	public function __construct() {
+	public static function init() {
 		// Nothing to do on autosave.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;

--- a/statify.php
+++ b/statify.php
@@ -28,7 +28,7 @@ add_action(
 	'plugins_loaded',
 	array(
 		'Statify',
-		'instance',
+		'init',
 	)
 );
 register_activation_hook(


### PR DESCRIPTION
As @bueltge commented in #116 

> I would see this statement, logic in a separate method and not logic inside the constructor. For me is more clear and on focus to switch to modern development we need to go to an empty constructor in context of usage from unit tests.

I agree with that statement, because the "constructor" does not construct anything meaningful here, but does various initialization tasks.
Because the constructor cannot be triggered from WP action hooks, there has been a static method `Statify::instance()` which is also not very speaking. I'd expect some kind of instantiation, singleton pattern or similar here, but it also does not do anything but constructing a (useless) object which triggers the initialization.

Moved the logic of `Statify` constructor into a new static method `Statify::init()`.

Because this is technically a breaking change in public API (although both methods are not intended to be used outside WP contexts), I declared both as _deprecated_ for now. To be removed with the next major release.