### PR TITLE
widget UI corrections + meta links below settings

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -52,6 +52,13 @@
 	color: #0074a2;
 }
 
+#statify_dashboard .postbox-title-action a,
+#statify_dashboard .settings-link a {
+	display: block;
+	line-height: 20px;
+	text-decoration: none;
+}
+
 #statify_dashboard .inside {
 	height: 1%;
 	margin: 0;

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -307,7 +307,7 @@ class Statify_Settings {
 				do_settings_sections( 'statify' );
 				submit_button();
 				?>
-				<p style="text-align:right;">
+				<p class="alignright">
 					<a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/statify/', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Documentation', 'statify' ); ?></a>
 					&bull; <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'statify' ); ?></a>
 					&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/support/plugin/statify', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'statify' ); ?></a>

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -307,6 +307,12 @@ class Statify_Settings {
 				do_settings_sections( 'statify' );
 				submit_button();
 				?>
+				<p style="text-align:right;">
+					<a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/statify/', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Documentation', 'statify' ); ?></a>
+					&bull; <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'statify' ); ?></a>
+					&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/support/plugin/statify', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'statify' ); ?></a>
+				</p>
+
 			</form>
 		</div>
 

--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -11,7 +11,7 @@
 class_exists( 'Statify' ) || exit; ?>
 
 <?php if ( current_user_can( 'manage_options' ) ) : ?>
-<p class="meta-links">
+<p class="meta-links settings-link">
 	<a href="<?php echo esc_attr( add_query_arg( array( 'page' => 'statify-settings' ), admin_url( '/options-general.php' ) ) ); ?>"
 		title="<?php esc_attr_e( 'Open full settings page', 'statify' ); ?>">
 		<span class="dashicons dashicons-admin-generic"></span>


### PR DESCRIPTION
Two minor changes:
* remove underlines from action-links (configure/cancel and "all settings") and align with dashicon
  * underlined icons are not beautiful
  * separates actions from real hyperlinks (still underliend) optically
![statify_widgetlinks](https://user-images.githubusercontent.com/12963621/79988614-2437c780-84af-11ea-894a-fcb2558653f1.png)
* copied the meta links (Documentation, Donate, Support) to the settings page
  * we have them there across all plugins with settings page