### PR TITLE
skip tracking for favicon.ico redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 * Introduced new option to separate display from storage range
 * Automatically add AMP analytics trigger if official AMP PlugIn is installed
 * Dashboard widget is now scrollable to keep long-term statistics readable
+* Skip tracking for favicon.ico redirects (since WP 5.4)
 
 ## 1.6.3
 * Fix compatibility issue with some PHP implementations not populating `INPUT_SERVER`

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -246,8 +246,9 @@ class Statify_Frontend extends Statify {
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */
 	private static function _is_internal() {
-		// Skip for preview, 404 calls, feed and search access.
-		return is_preview() || is_404() || is_feed() || is_search();
+		// Skip for preview, 404 calls, feed, search and favicon access.
+		return is_preview() || is_404() || is_feed() || is_search()
+			|| ( function_exists( 'is_favicon' ) && is_favicon() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes WP 5.4 issue reported in WP support forums:
https://wordpress.org/support/topic/favicon-ico/

In WP 5.4 the favicon fallback has been refactored for more flexibility<sup>1</sup>.
Due to that behavior, plugins are now initialized before the redirect to the actual icon file and Statify tracks the visit.

Introduce another exclusion, s.t. those calls are treated as "internal" and thus skipped. Utilizes the newly introduces `is_favicon()` check<sup>2</sup>.

[1] https://make.wordpress.org/core/2020/02/19/enhancements-to-favicon-handling-in-wordpress-5-4/
[2] https://developer.wordpress.org/reference/functions/is_favicon/