### PR TITLE
add .distignore for automatic deployment control

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,20 @@
+# Directories
+/.git
+/.github
+/.wordpress-org
+/node_modules
+/vendor
+
+# Files
+/.distignore
+/.eslintrc.json
+/.gitattributes
+/.gitignore
+/.stylelintrc.json
+/.travis.yml
+/composer.json
+/package.json
+/package-lock.json
+/composer.lock
+/phpcs.xml
+/README.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /vendor export-ignore
 
 # Files
+/.distignore export-ignore
 /.eslintrc.json export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
The deployment action utilizes `git archive` if no _.distignore_ is specified. Doing so, the minified JS/CSS resources are ignored, because not only _.gitattributes_ is processed, but due to _.gitignore_ the _*.min.[js|css]_ files have never been added to git and won't become part of the archive.

Using explicit _.distignore_ list we now separate git / Compsoer excludes from WP deployment. This triggers simple `rsync` without git logic.