### PR TITLE
fix inconsistency between number of total visits and first date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Fix date inconsistency for number of total visits (#150)
+
 ## 1.7.0
 * Fix JavaScript embedding when bots visit before caching (#84) (#86) 
 * Fix offset in visitor reporting due to different timezones between PHP and database (#117, props @sophiehuiberts)

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -380,8 +380,9 @@ class Statify_Dashboard extends Statify {
 						$current_date
 					)
 				),
-				'since_beginning' => $wpdb->get_var(
-					"SELECT COUNT(`created`) FROM `$wpdb->statify`"
+				'since_beginning' => $wpdb->get_row(
+					"SELECT COUNT(`created`) AS `count`, MIN(`created`) AS `date` FROM `$wpdb->statify`",
+					ARRAY_A
 				),
 			);
 		}

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -101,11 +101,11 @@ $stats = Statify_Dashboard::get_stats(); ?>
 				</tr>
 				<tr>
 					<td class="b">
-						<?php echo (int) $stats['visit_totals']['since_beginning']; ?>
+						<?php echo (int) $stats['visit_totals']['since_beginning']['count']; ?>
 					</td>
 					<td class="t">
 						<?php esc_html_e( 'since', 'statify' ); ?>
-						<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $stats['visits'][0]['date'] ) ) ); ?>
+						<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $stats['visit_totals']['since_beginning']['date'] ) ) ); ?>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
Initially reported in WP support forums (German): https://wordpress.org/support/topic/zeige-gesamtzahlen-dashboard/

Date has been taken from the first data point of the output range while the total number of hits is directly requested from the database.

Apparently the shortcut of simply copying the first date in the output array (`$stats['visits'][0]['date']`) was correct when #134 has been opened, but has become incorrect when #72 has finally been merged which split the display and storage range.

Now the first date is also qeueried along with the total count.