### PR TITLE
extend user agent filter by "python", "wget" and "monitor"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Extend user agent filter for bot detection (#149) (#151)
+
 ## 1.7.0
 * Fix JavaScript embedding when bots visit before caching (#84) (#86) 
 * Fix offset in visitor reporting due to different timezones between PHP and database (#117, props @sophiehuiberts)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -227,6 +227,9 @@ class Statify_Frontend extends Statify {
 			'curl',
 			'facebook',
 			'fetch',
+			'python',
+			'wget',
+			'monitor',
 		);
 
 		foreach ( $identifiers as $identifier ) {


### PR DESCRIPTION
Fixes #149 

Back in #125 the user agent filter for bot detection has been reworked.
As @KittMedia already mentioned in https://github.com/pluginkollektiv/statify/pull/125#issuecomment-475591309 the `wget` identifier has been forgotten while `curl` is present. Never taken care of that...

Also commonly used monitoring tools like Nagios/Icinga or PRTG are not excluded. They are not "bots" in terms of crawlers/spiders, but also non-human requests which are not meant to be counted. Both contain the word "monitor(ing)" while afaik no client webbrowser contains this.

I've also added `python`, because it's quite common for analysis scripts and bots as well.

Example UA strings that pass the 1.7 filter, but shouldn't:
```text
Wget/1.20.3 (linux-gnu)
Python-urllib/3.8
python-requests/2.22.0
check_http/v2.2 (monitoring-plugins 2.2)
Mozilla/5.0 (compatible; PRTG Network Monitor (www.paessler.com); Windows)
```

The latter also passed the <=1.6 filter, because it contains "Windows"...