### PR TITLE
add action after options change to delete transients and flush Cachify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## unreleased
 * Fix refresh of the dashboard widget when settings have been changed through the settings page (#147)
+* Fix _Cachify_ cache not being flushed after changing JavaScript settings (#152)
 
 ## 1.7.0
 * Fix JavaScript embedding when bots visit before caching (#84) (#86) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Fix refresh of the dashboard widget when settings have been changed through the settings page (#147)
+
 ## 1.7.0
 * Fix JavaScript embedding when bots visit before caching (#84) (#86) 
 * Fix offset in visitor reporting due to different timezones between PHP and database (#117, props @sophiehuiberts)

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -241,9 +241,6 @@ class Statify_Dashboard extends Statify {
 		// Update values.
 		update_option( 'statify', $options );
 
-		// Delete transient.
-		delete_transient( 'statify_data' );
-
 		// Clear Cachify cache.
 		if ( has_action( 'cachify_flush_cache' ) ) {
 			do_action( 'cachify_flush_cache' );

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -240,11 +240,6 @@ class Statify_Dashboard extends Statify {
 
 		// Update values.
 		update_option( 'statify', $options );
-
-		// Clear Cachify cache.
-		if ( has_action( 'cachify_flush_cache' ) ) {
-			do_action( 'cachify_flush_cache' );
-		}
 	}
 
 

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -246,6 +246,19 @@ class Statify_Settings {
 	}
 
 	/**
+	 * Action to be triggered after Statify options have been saved.
+	 * Delete transient data to refresh the dashboard widget.
+	 *
+	 * @since 1.7.1
+	 *
+	 * @return void
+	 */
+	public static function action_update_options( ) {
+		// Delete transient.
+		delete_transient( 'statify_data' );
+	}
+
+	/**
 	 * Validate and sanitize submitted options.
 	 *
 	 * @param array $options Original options.

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -247,15 +247,24 @@ class Statify_Settings {
 
 	/**
 	 * Action to be triggered after Statify options have been saved.
-	 * Delete transient data to refresh the dashboard widget.
+	 * Delete transient data to refresh the dashboard widget and flushes Cachify cache, if the plugin is available and
+	 * JS settings have changed.
 	 *
 	 * @since 1.7.1
 	 *
+	 * @param array $old_value The old options value.
+	 * @param array $value     The updated options value.
+	 *
 	 * @return void
 	 */
-	public static function action_update_options( ) {
+	public static function action_update_options( $old_value, $value ) {
 		// Delete transient.
 		delete_transient( 'statify_data' );
+
+		// Clear Cachify cache, if JS settings have changed.
+		if ( $old_value['snippet'] !== $value['snippet'] && has_action( 'cachify_flush_cache' ) ) {
+			do_action( 'cachify_flush_cache' );
+		}
 	}
 
 	/**

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -94,6 +94,7 @@ class Statify {
 			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify_Backend', 'add_action_link' ) );
 			add_action( 'admin_init', array( 'Statify_Settings', 'register_settings' ) );
 			add_action( 'admin_menu', array( 'Statify_Settings', 'add_admin_menu' ) );
+			add_action( 'update_option_statify', array( 'Statify_Settings', 'action_update_options' ) );
 		} else {    // Frontend.
 			add_action( 'template_redirect', array( 'Statify_Frontend', 'track_visit' ) );
 			add_filter( 'query_vars', array( 'Statify_Frontend', 'query_vars' ) );

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -94,7 +94,7 @@ class Statify {
 			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify_Backend', 'add_action_link' ) );
 			add_action( 'admin_init', array( 'Statify_Settings', 'register_settings' ) );
 			add_action( 'admin_menu', array( 'Statify_Settings', 'add_admin_menu' ) );
-			add_action( 'update_option_statify', array( 'Statify_Settings', 'action_update_options' ) );
+			add_action( 'update_option_statify', array( 'Statify_Settings', 'action_update_options' ), 10, 2 );
 		} else {    // Frontend.
 			add_action( 'template_redirect', array( 'Statify_Frontend', 'track_visit' ) );
 			add_filter( 'query_vars', array( 'Statify_Frontend', 'query_vars' ) );


### PR DESCRIPTION
Supersedes #148.
Fixes #147 and fixes #152.

Introduce a new action hook for [`update_option_statify`](https://developer.wordpress.org/reference/hooks/update_option_option/) as suggested by @chesio.

In contrast to #148 this allows easy extension to get around the problem that Cachify cache was not flushed. This is now fixed with minor enhancement that it's only flushed if JS settings have actually changed.