### PR TITLE
always register private AJAX action to prevent error 400 if logged-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)
+
 ## 1.7.1
 * Fix refresh of the dashboard widget when settings have been changed through the settings page (#147)
 * Fix _Cachify_ cache not being flushed after changing JavaScript settings (#152)

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -79,9 +79,7 @@ class Statify {
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			add_action( 'wp_ajax_nopriv_statify_track', array( 'Statify_Frontend', 'track_visit_ajax' ) );
-			if ( 0 === self::$_options['skip']['logged_in'] ) {
-				add_action( 'wp_ajax_statify_track', array( 'Statify_Frontend', 'track_visit_ajax' ) );
-			}
+			add_action( 'wp_ajax_statify_track', array( 'Statify_Frontend', 'track_visit_ajax' ) );
 		} elseif ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {  // XMLRPC.
 			add_filter( 'xmlrpc_methods', array( 'Statify_XMLRPC', 'xmlrpc_methods' ) );
 		} elseif ( defined( 'DOING_CRON' ) && DOING_CRON ) {    // Cron.


### PR DESCRIPTION
Fixes an issue that has been reported in WP support forums (switches to German at comment 4):
https://wordpress.org/support/topic/statify-causes-400-error-admin-ajax-php/

**Steps to reproduce:**
* JavaScript tracking enabled
* Tracking disabled for logged-in users (default)
* Visit the site while logged-in

**Behavior:**
The _Statify_ JS snippet calls the `admin-ajax.php` endpoint for logged-in users. This request results in error code 400 (invalid request, because the action does not exist).

**Impact:**
In most cases, the visit counts are _not_ affected. If tracking is disabled for logged-in users, the visit is not counted anyway. However the log gets messed up with unnecessary errors.

If custom logic has been used to track logged-in users (necessary before 1.7 because there was no option for that), this does not work anymore!

**Solution:**
Always register the private AJAX action and rely on `_skip_tracking()` to not count the visits.