### PR TITLE
use wp_die() instead of header and exit for AJAX requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## unreleased
 * Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)
+* Use `wp_die()` instead of header and exit for AJAX requests (#160)
 
 ## 1.7.1
 * Fix refresh of the dashboard widget when settings have been changed through the settings page (#147)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -331,8 +331,7 @@ class Statify_Frontend extends Statify {
 
 		if ( $is_snippet ) {
 			nocache_headers();
-			header( 'Content-type: text/javascript', true, 204 );
-			exit;
+			wp_die( '', '', 204 );
 		}
 
 		return false;


### PR DESCRIPTION
Use WP builtin wp_die() logic with overwritten response code 204 for AJAX jump-out after the tracking action.

This allows other logic to clean up as designed while calling exit directly does not. It also makes integration testing easier (currently working on that).

~I cannot remember why the _Content-Type: application/javascript_ was necessary, but I guess it's just a residual artifact from previous logic.~

The _Content-Type: application/javascript_ header is not required since the pseudo `<script>`-tag has been replaced by an explicit XHR call in 1.6.3 (#92), so we can omit it without consequences here. (content type for "no content" does not really make sense anyway)