### PR TITLE
fix 1 day offset for top list range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 ## unreleased
 * Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)
 * Use `wp_die()` instead of header and exit for AJAX requests (#160)
+* Fix 1 day offset between display range and number of days evaluated in top lists (#162)
 
 ## 1.7.1
 * Fix refresh of the dashboard widget when settings have been changed through the settings page (#147)

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -346,7 +346,7 @@ class Statify_Dashboard extends Statify {
 		} else {
 			$data['target'] = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT COUNT(`target`) as `count`, `target` as `url` FROM `$wpdb->statify` WHERE created >= DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `target` ORDER BY `count` DESC LIMIT %d",
+					"SELECT COUNT(`target`) as `count`, `target` as `url` FROM `$wpdb->statify` WHERE created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `target` ORDER BY `count` DESC LIMIT %d",
 					$current_date,
 					$days_show,
 					$limit
@@ -355,7 +355,7 @@ class Statify_Dashboard extends Statify {
 			);
 			$data['referrer'] = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT COUNT(`referrer`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created >= DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `host` ORDER BY `count` DESC LIMIT %d",
+					"SELECT COUNT(`referrer`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `host` ORDER BY `count` DESC LIMIT %d",
 					$current_date,
 					$days_show,
 					$limit


### PR DESCRIPTION
Top lists are either generated for "today" or for the whole display range.

The underlying query however returns one day more than expected, if storage range is greater display range.

```sql
... WHERE created >= DATE_SUB(%s, INTERVAL %d DAY)
```
obviously fetches data of "_x_ days ago" inclusive which makes _x+1_ days with today, so one more than expected.

The visit query is not affected because it uses `LIMIT %d` in the aggregation query and the Cron cleanup uses `created <= DATE_SUB(...)` so it's done right there.