### PR TITLE
Fix readme/asset update action 

### DIFF
--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - uses: php-actions/composer@v1
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@master
       env:

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,7 @@ If you've problems or think you’ve found a bug (e.g. you’re experiencing une
 * previews
 * views by logged in users (unless tracking is activated via the settings page)
 * error pages
+* favicon (as of WP 5.4)
 
 This behavior can be modified with the `statify__skip_tracking` hook.
 


### PR DESCRIPTION
This bugfix should avoid diff in missing minified files by running composer install - the postinstall action will generate the required files.