### PR TITLE
use wp_date() to fix possible date offset in WP 5.3 sites (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones
+
 ## 1.7.2
 * Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)
 * Use `wp_die()` instead of header and exit for AJAX requests (#160)

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -102,4 +102,23 @@ class Statify {
 			}
 		}
 	}
+
+	/**
+	 * Get a readable date from YYYY-MM-DD database date.
+	 *
+	 * This function is designed as a wrapper around date_i18n() or wp_date(), if the latter is available (#166).
+	 *
+	 * @param string $date Raw date in "YYYY-MM-DD" format.
+	 *
+	 * @return string Parsed date in WP default format.
+	 *
+	 * @since 1.7.3
+	 */
+	public static function parse_date( $date ) {
+		if ( function_exists( 'wp_date' ) ) { // Exists since WP 5.3.
+			return wp_date( get_option( 'date_format' ), strtotime( $date ) );
+		}
+
+		return date_i18n( get_option( 'date_format' ), strtotime( $date ) );
+	}
 }

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -22,7 +22,7 @@ $stats = Statify_Dashboard::get_stats(); ?>
 			<table id="statify_chart_data">
 				<?php foreach ( (array) $stats['visits'] as $visit ) { ?>
 					<tr>
-						<th><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $visit['date'] ) ) ); ?></th>
+						<th><?php echo esc_html( Statify::parse_date( $visit['date'] ) ); ?></th>
 						<td><?php echo (int) $visit['count']; ?></td>
 					</tr>
 				<?php } ?>
@@ -105,7 +105,7 @@ $stats = Statify_Dashboard::get_stats(); ?>
 					</td>
 					<td class="t">
 						<?php esc_html_e( 'since', 'statify' ); ?>
-						<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $stats['visit_totals']['since_beginning']['date'] ) ) ); ?>
+						<?php echo esc_html( Statify::parse_date( $stats['visit_totals']['since_beginning']['date'] ) ); ?>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
This PR fixes #166.

Introduce a new wrapper function `Statify::parse_date( $date )` that uses `wp_date()` when available (WP 5.3+) with fallback to the previous `date_i18n()` call.

`date_i18n()` is a wrapper for `wp_date()` since WP 5.3 and tries to re-calculate the timezone offset. This clashes in several scenarios when the date (implicitly 00:00:00) is shifted back, s.t. the dashboard widget shows an offset of -1 day in these cases.