### PR TITLE
Add an option to deactivate the nonce check during JavaScript tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## unreleased
-* Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones
+* Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)
+* Allow to deactivate the nonce check during JavaScript tracking (#168)
 
 ## 1.7.2
 * Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -30,29 +30,27 @@ class Statify_Frontend extends Statify {
 	 * @return   boolean
 	 */
 	public static function track_visit( $is_snippet = false ) {
-
-		// Check of JS snippet is configured.
-		$use_snippet = self::$_options['snippet'];
-
 		// Set target & referrer.
 		$target   = null;
 		$referrer = null;
-		if ( $use_snippet && $is_snippet ) {
-			if ( isset( $_REQUEST['statify_target'] ) ) {
-				$target = filter_var( wp_unslash( $_REQUEST['statify_target'] ), FILTER_SANITIZE_URL );
+		if ( self::is_javascript_tracking_enabled() ) {
+			if ( $is_snippet ) {
+				if ( isset( $_REQUEST['statify_target'] ) ) {
+					$target = filter_var( wp_unslash( $_REQUEST['statify_target'] ), FILTER_SANITIZE_URL );
+				}
+				if ( isset( $_REQUEST['statify_referrer'] ) ) {
+					$referrer = filter_var( wp_unslash( $_REQUEST['statify_referrer'] ), FILTER_SANITIZE_URL );
+				}
+			} else {
+				return false;
 			}
-			if ( isset( $_REQUEST['statify_referrer'] ) ) {
-				$referrer = filter_var( wp_unslash( $_REQUEST['statify_referrer'] ), FILTER_SANITIZE_URL );
-			}
-		} elseif ( ! $use_snippet ) {
+		} else {
 			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 				$target = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
 			}
 			if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
 				$referrer = filter_var( wp_unslash( $_SERVER['HTTP_REFERER'] ), FILTER_SANITIZE_URL );
 			}
-		} else {
-			return false;
 		}
 
 		// Fallbacks for uninitialized or omitted target and referrer values.
@@ -127,14 +125,17 @@ class Statify_Frontend extends Statify {
 	 * @return void
 	 */
 	public static function track_visit_ajax() {
+		// Only do something if snippet use is actually configured.
+		if ( ! self::is_javascript_tracking_enabled() ) {
+			return;
+		}
+
 		// Check AJAX referrer.
-		if ( self::$_options['nonce'] ) {
+		if ( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK === self::$_options['snippet'] ) {
 			check_ajax_referer( 'statify_track' );
 		}
-		// Only do something if snippet use is actually configured.
-		if ( self::$_options['snippet'] ) {
-			self::track_visit( true );
-		}
+
+		self::track_visit( true );
 	}
 
 	/**
@@ -366,9 +367,8 @@ class Statify_Frontend extends Statify {
 	 * @version  1.4.1
 	 */
 	public static function wp_footer() {
-
 		// Skip by option.
-		if ( ! self::$_options['snippet'] ) {
+		if ( ! self::is_javascript_tracking_enabled() ) {
 			return;
 		}
 
@@ -409,7 +409,7 @@ class Statify_Frontend extends Statify {
 		}
 
 		// Analytics script is only relevant, if "JS" tracking is enabled, to prevent double tracking.
-		if ( self::$_options['snippet'] ) {
+		if ( self::is_javascript_tracking_enabled() ) {
 			$analytics['statify'] = array(
 				'type'        => '',
 				'attributes'  => array(),

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -34,15 +34,15 @@ class Statify_Frontend extends Statify {
 		$target   = null;
 		$referrer = null;
 		if ( self::is_javascript_tracking_enabled() ) {
-			if ( $is_snippet ) {
-				if ( isset( $_REQUEST['statify_target'] ) ) {
-					$target = filter_var( wp_unslash( $_REQUEST['statify_target'] ), FILTER_SANITIZE_URL );
-				}
-				if ( isset( $_REQUEST['statify_referrer'] ) ) {
-					$referrer = filter_var( wp_unslash( $_REQUEST['statify_referrer'] ), FILTER_SANITIZE_URL );
-				}
-			} else {
+			if ( ! $is_snippet ) {
 				return false;
+			}
+
+			if ( isset( $_REQUEST['statify_target'] ) ) {
+				$target = filter_var( wp_unslash( $_REQUEST['statify_target'] ), FILTER_SANITIZE_URL );
+			}
+			if ( isset( $_REQUEST['statify_referrer'] ) ) {
+				$referrer = filter_var( wp_unslash( $_REQUEST['statify_referrer'] ), FILTER_SANITIZE_URL );
 			}
 		} else {
 			if ( isset( $_SERVER['REQUEST_URI'] ) ) {

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -128,7 +128,9 @@ class Statify_Frontend extends Statify {
 	 */
 	public static function track_visit_ajax() {
 		// Check AJAX referrer.
-		check_ajax_referer( 'statify_track' );
+		if ( self::$_options['nonce'] ) {
+			check_ajax_referer( 'statify_track' );
+		}
 		// Only do something if snippet use is actually configured.
 		if ( self::$_options['snippet'] ) {
 			self::track_visit( true );

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -8,7 +8,7 @@
  * @since     1.7
  */
 
-// Quit ic accessed directly..
+// Quit if accessed directly..
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -48,6 +48,14 @@ class Statify_Settings {
 			'statify',
 			'statify-global',
 			array( 'label_for' => 'statify-snippet' )
+		);
+		add_settings_field(
+			'statify-snippet-nonce',
+			__( 'Require nonce for JavaScript tracking', 'statify' ),
+			array( __CLASS__, 'options_nonce' ),
+			'statify',
+			'statify-global',
+			array( 'label_for' => 'statify-nonce' )
 		);
 
 		// Dashboard widget settings.
@@ -139,6 +147,22 @@ class Statify_Settings {
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
 		<br>
 		<p class="description"><?php esc_html_e( 'This option is strongly recommended if caching or AMP is in use.', 'statify' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Option for the nonce for tracking via JS.
+	 *
+	 * @since 1.7.3
+	 *
+	 * @return void
+	 */
+	public static function options_nonce() {
+		?>
+		<input id="statify-nonce" type="checkbox" name="statify[nonce]" value="1" <?php checked( Statify::$_options['nonce'], 1 ); ?>>
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
+		<br>
+		<p class="description"><?php esc_html_e( 'Activate this setting if the caching time is longer than the nonce time.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -289,7 +313,7 @@ class Statify_Settings {
 		}
 
 		// Get checkbox values.
-		foreach ( array( 'today', 'snippet', 'blacklist', 'show_totals' ) as $o ) {
+		foreach ( array( 'today', 'snippet', 'nonce', 'blacklist', 'show_totals' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
 		$res['skip']['logged_in'] = isset( $options['skip']['logged_in'] ) && 1 === (int) $options['skip']['logged_in'] ? 1 : 0;

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -43,19 +43,11 @@ class Statify_Settings {
 		);
 		add_settings_field(
 			'statify-snippet',
-			__( 'Tracking via JavaScript', 'statify' ),
+			__( 'Tracking method', 'statify' ),
 			array( __CLASS__, 'options_snippet' ),
 			'statify',
 			'statify-global',
 			array( 'label_for' => 'statify-snippet' )
-		);
-		add_settings_field(
-			'statify-snippet-nonce',
-			__( 'Require nonce for JavaScript tracking', 'statify' ),
-			array( __CLASS__, 'options_nonce' ),
-			'statify',
-			'statify-global',
-			array( 'label_for' => 'statify-nonce' )
 		);
 
 		// Dashboard widget settings.
@@ -143,26 +135,32 @@ class Statify_Settings {
 	 */
 	public static function options_snippet() {
 		?>
-		<input id="statify-snippet" type="checkbox" name="statify[snippet]" value="1" <?php checked( Statify::$_options['snippet'], 1 ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
-		<br>
-		<p class="description"><?php esc_html_e( 'This option is strongly recommended if caching or AMP is in use.', 'statify' ); ?></p>
+		<p>
+			<?php self::show_snippet_option( Statify::TRACKING_METHOD_DEFAULT, __( 'Default tracking', 'statify' ) ); ?>
+			<br>
+			<?php self::show_snippet_option( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK, __( 'JavaScript based tracking with nonce check', 'statify' ) ); ?>
+			<br>
+			<?php self::show_snippet_option( Statify::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK, __( 'JavaScript based tracking without nonce check', 'statify' ) ); ?>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'JavaScript based tracking is strongly recommended if caching or AMP is in use.', 'statify' ); ?>
+			<?php esc_html_e( 'Disable the nonce check if the caching time is longer than the nonce time or you miss views due to 403 Forbidden errors.', 'statify' ); ?>
+		</p>
 		<?php
 	}
 
 	/**
-	 * Option for the nonce for tracking via JS.
+	 * Outputs the input radio for an option.
 	 *
-	 * @since 1.7.3
-	 *
-	 * @return void
+	 * @param int    $value the value for the input radio.
+	 * @param string $label the label.
 	 */
-	public static function options_nonce() {
+	private static function show_snippet_option( $value, $label ) {
 		?>
-		<input id="statify-nonce" type="checkbox" name="statify[nonce]" value="1" <?php checked( Statify::$_options['nonce'], 1 ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
-		<br>
-		<p class="description"><?php esc_html_e( 'Activate this setting if the caching time is longer than the nonce time or you miss views due to 403 Forbidden errors.', 'statify' ); ?></p>
+			<label>
+				<input name="statify[snippet]" type="radio" value="<?php echo esc_html( $value ); ?>>" <?php checked( Statify::$_options['snippet'], $value ); ?>>
+				<?php echo esc_html( $label ); ?>
+			</label>
 		<?php
 	}
 
@@ -250,7 +248,6 @@ class Statify_Settings {
 		?>
 		<input id="statify-skip-referrer" type="checkbox" name="statify[blacklist]" value="1"<?php checked( Statify::$_options['blacklist'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
-		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views with referrers listed in the comment blacklist.', 'statify' ); ?></p>
 		<?php
 	}
@@ -264,7 +261,6 @@ class Statify_Settings {
 		?>
 		<input id="statify-skip-logged_in" type="checkbox" name="statify[skip][logged_in]" value="1"<?php checked( Statify::$_options['skip']['logged_in'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
-		<br>
 		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views of logged-in users from tracking.', 'statify' ); ?></p>
 		<?php
 	}
@@ -312,8 +308,23 @@ class Statify_Settings {
 			$res['limit'] = 100;
 		}
 
+		if ( isset( $options['snippet'] ) ) {
+			$method = (int) $options['snippet'];
+			if ( in_array(
+				$method,
+				array(
+					Statify::TRACKING_METHOD_DEFAULT,
+					Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK,
+					Statify::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK,
+				),
+				true
+			) ) {
+				$res['snippet'] = $method;
+			}
+		}
+
 		// Get checkbox values.
-		foreach ( array( 'today', 'snippet', 'nonce', 'blacklist', 'show_totals' ) as $o ) {
+		foreach ( array( 'today', 'blacklist', 'show_totals' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
 		$res['skip']['logged_in'] = isset( $options['skip']['logged_in'] ) && 1 === (int) $options['skip']['logged_in'] ? 1 : 0;

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -162,7 +162,7 @@ class Statify_Settings {
 		<input id="statify-nonce" type="checkbox" name="statify[nonce]" value="1" <?php checked( Statify::$_options['nonce'], 1 ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
 		<br>
-		<p class="description"><?php esc_html_e( 'Activate this setting if the caching time is longer than the nonce time.', 'statify' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Activate this setting if the caching time is longer than the nonce time or you miss views due to 403 Forbidden errors.', 'statify' ); ?></p>
 		<?php
 	}
 

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -69,6 +69,7 @@ class Statify {
 				'limit'       => 3,
 				'today'       => 0,
 				'snippet'     => 0,
+				'nonce'       => 1,
 				'blacklist'   => 0,
 				'show_totals' => 0,
 				'skip'        => array(

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -17,6 +17,9 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.1.0
  */
 class Statify {
+	const TRACKING_METHOD_DEFAULT = 0;
+	const TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK = 1;
+	const TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK = 2;
 
 	/**
 	 * Plugin options.
@@ -25,26 +28,6 @@ class Statify {
 	 * @var    array $_options
 	 */
 	public static $_options;
-
-	/**
-	 * Class constructor
-	 *
-	 * @since      0.1.0
-	 * @deprecated As of 1.7 use static method init() to initialize the plugin.
-	 */
-	public function __construct() {
-		self::init();
-	}
-
-	/**
-	 * Class self initialize.
-	 *
-	 * @since      0.1.0
-	 * @deprecated As of 1.7 use init() to initialize the plugin.
-	 */
-	public static function instance() {
-		self::init();
-	}
 
 	/**
 	 * Plugin initialization.
@@ -69,7 +52,6 @@ class Statify {
 				'limit'       => 3,
 				'today'       => 0,
 				'snippet'     => 0,
-				'nonce'       => 1,
 				'blacklist'   => 0,
 				'show_totals' => 0,
 				'skip'        => array(
@@ -121,5 +103,21 @@ class Statify {
 		}
 
 		return date_i18n( get_option( 'date_format' ), strtotime( $date ) );
+	}
+
+	/**
+	 * Check JavaScript tracking.
+	 *
+	 * @return bool true if and only if one of the JavaScript tracking options is enabled.
+	 */
+	public static function is_javascript_tracking_enabled() {
+		return in_array(
+			self::$_options['snippet'],
+			array(
+				self::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK,
+				self::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK,
+			),
+			true
+		);
 	}
 }


### PR DESCRIPTION
We got some reports that Statify tracks less views on WP sites which have a long caching duration enabled. The problem in those installations may be that the nonce (expires after ~24 h) is not valid anymore and the view is not tracked. We discussed that we could make the nonce check optional - this PR implements this idea.