### PR TITLE
support "disallowed_keys" instead of "blacklist" for WP 5.5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 ## unreleased
 * Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)
 * Allow to deactivate the nonce check during JavaScript tracking (#168)
+* Add support for "disallowed_keys" option instead of "blacklist_keys" in WordPress 5.5 (#174)
 
 ## 1.7.2
 * Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -258,17 +258,17 @@ class Statify_Frontend extends Statify {
 	}
 
 	/**
-	 * Compare the referrer url to the blacklist data.
+	 * Compare the referrer URL to the disallowed keys list.
 	 * De/activate this feature via settings in the Dashboard widget.
 	 *
 	 * @since   1.5.0
 	 * @version 1.6.3
 	 *
-	 * @return  boolean TRUE of referrer matches blacklist entry and should thus be excluded.
+	 * @return  boolean TRUE of referrer matches disallowed keys entry and should thus be excluded.
 	 */
 	private static function check_referrer() {
 
-		// Return false if the blacklist filter is inactive.
+		// Return false if the disallowed-keys filter (formerly blacklist) is inactive.
 		if ( ! self::$_options['blacklist'] ) {
 			return false;
 		}
@@ -291,9 +291,9 @@ class Statify_Frontend extends Statify {
 			return false;
 		}
 
-		// Finally compare referrer against the blacklist.
-		$blacklist = self::get_blacklist_keys();
-		foreach ( $blacklist as $item ) {
+		// Finally compare referrer against the disallowed keys.
+		$disallowed_keys = self::get_disallowed_keys();
+		foreach ( $disallowed_keys as $item ) {
 			if ( strpos( $referrer, $item ) !== false ) {
 				return true;
 			}
@@ -303,21 +303,28 @@ class Statify_Frontend extends Statify {
 	}
 
 	/**
-	 * Get a array from the blacklist option of 'Settings' - 'Discussion' - 'Comment Blacklist'.
+	 * Get a array from the disallowed_keys option of 'Settings' - 'Discussion' - 'Disallowed Comment Keys'.
 	 *
 	 * @since  2016-12-21
+	 * @since 1.7.3 Renamed to "get_disallowed_keys" to match WP 5.5. wording.
 	 *
 	 * @return array
 	 */
-	private static function get_blacklist_keys() {
+	private static function get_disallowed_keys() {
+		$disallowed_keys = get_option( 'disallowed_keys' );
 
-		$blacklist = trim( get_option( 'blacklist_keys' ) );
+		if ( false === $disallowed_keys ) {
+			// WordPress < 5.5 uses the old key.
+			$disallowed_keys = get_option( 'blacklist_keys' );
+		}
 
-		if ( empty( $blacklist ) ) {
+		$disallowed_keys = trim( $disallowed_keys );
+
+		if ( empty( $disallowed_keys ) ) {
 			return array();
 		}
 
-		return (array) explode( "\n", $blacklist );
+		return (array) explode( "\n", $disallowed_keys );
 	}
 
 	/**

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -99,7 +99,7 @@ class Statify_Settings {
 		);
 		add_settings_field(
 			'statify-skip-referrer',
-			__( 'Blacklisted referrers', 'statify' ),
+			__( 'Disallowed referrers', 'statify' ),
 			array( __CLASS__, 'options_skip_blacklist' ),
 			'statify',
 			'statify-skip',
@@ -240,7 +240,7 @@ class Statify_Settings {
 	}
 
 	/**
-	 * Option to skip tracking for blacklisted referrers.
+	 * Option to skip tracking for disallowed referrers.
 	 *
 	 * @return void
 	 */
@@ -248,7 +248,7 @@ class Statify_Settings {
 		?>
 		<input id="statify-skip-referrer" type="checkbox" name="statify[blacklist]" value="1"<?php checked( Statify::$_options['blacklist'] ); ?>>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
-		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views with referrers listed in the comment blacklist.', 'statify' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views with referrers listed in the list of disallowed comment keys.', 'statify' ); ?></p>
 		<?php
 	}
 


### PR DESCRIPTION
In _WordPress_ 5.5 the "comment blacklist" has been renamed to "disallowed comment keys" along with the corresponding option key<sup>[1](#fn1)</sup>.

We now support the new option, if available.
Also the frontend wording is adapted to match the new labels.
Private methods and comments changed where reasonable. Public methods and internal option names left untouched for backwards compatibility.

[<a name="fn1">1</a>] https://make.wordpress.org/core/2020/07/23/codebase-language-improvements-in-5-5/