### PR TITLE
Fix hierarchy in the readme.txt changelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -116,13 +116,13 @@ has to be added to the theme's `functions.php`. The condition has modified such 
 ## Changelog ##
 You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
 
-## 1.8.0
+### 1.8.0
 * Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)
 * Allow to deactivate the nonce check during JavaScript tracking (#168)
 * Add support for "disallowed_keys" option instead of "blacklist_keys" in WordPress 5.5 (#174)
 * Add refresh button in the dashboard, increase caching time (#157)
 
-## 1.7.2
+### 1.7.2
 * Prevent JavaScript tracking from raising 400 for logged-in users, if tracking is disabled (#159)
 * Use `wp_die()` instead of header and exit for AJAX requests (#160)
 * Fix 1 day offset between display range and number of days evaluated in top lists (#162)


### PR DESCRIPTION
On https://wordpress.org/plugins/statify/ the hierarchy seems to be broken as the changelog of the version is shown in the _Description_ section of the _Details_ tab and not in the _Changelog_ section of the _Development_ tab.

Looking at our readme.txt I found the inconsistency in the hierarchy (number of # before the version number).