### PR TITLE
fix AMP compatibility for Standard and Transitional mode (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 1.8.1
 * Fix AMP compatiblity for Standard and Transitional mode (#181) (#182)
+* JavaScript is no longer embedded if request is served by AMP (#181) (#182)
 
 ## 1.8.0
 * Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.8.1
+* Fix AMP compatiblity for Standard and Transitional mode (#181) (#182)
+
 ## 1.8.0
 * Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)
 * Allow to deactivate the nonce check during JavaScript tracking (#168)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -410,7 +410,7 @@ class Statify_Frontend extends Statify {
 	/**
 	 * Add amp-analytics for Standard and Transitional mode.
 	 *
-	 * @see hAMPttps://amp-wp.org/documentation/playbooks/analytics/
+	 * @see https://amp-wp.org/documentation/playbooks/analytics/
 	 *
 	 * @param array $analytics_entries Analytics entries.
 	 */
@@ -475,6 +475,11 @@ class Statify_Frontend extends Statify {
 					'on'      => 'visible',
 					'request' => 'pageview',
 				),
+			),
+			'transport'      => array(
+				'beacon'  => true,
+				'xhrpost' => true,
+				'image'   => false,
 			),
 		);
 	}

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -404,7 +404,30 @@ class Statify_Frontend extends Statify {
 	}
 
 	/**
-	 * Add amp-analytics.
+	 * Add amp-analytics for Standard and Transitional mode.
+	 *
+	 * @see hAMPttps://amp-wp.org/documentation/playbooks/analytics/
+	 *
+	 * @param array $analytics_entries Analytics entries.
+	 */
+	public static function amp_analytics_entries( $analytics_entries ) {
+		if ( ! is_array( $analytics_entries ) ) {
+			$analytics_entries = array();
+		}
+
+		// Analytics script is only relevant, if "JS" tracking is enabled, to prevent double tracking.
+		if ( self::is_javascript_tracking_enabled() ) {
+			$analytics_entries['statify'] = array(
+				'type'   => '',
+				'config' => wp_json_encode( self::make_amp_config() ),
+			);
+		}
+
+		return $analytics_entries;
+	}
+
+	/**
+	 * Add AMP-analytics for Reader mode.
 	 *
 	 * @see https://amp-wp.org/documentation/playbooks/analytics/
 	 *
@@ -420,32 +443,35 @@ class Statify_Frontend extends Statify {
 			$analytics['statify'] = array(
 				'type'        => '',
 				'attributes'  => array(),
-				'config_data' => array(
-					'extraUrlParams' => array(
-						'action'           => 'statify_track',
-						'_ajax_nonce'      => wp_create_nonce( 'statify_track' ),
-						'statify_referrer' => '${documentReferrer}',
-						'statify_target'   => '${canonicalPath}amp/',
-					),
-					'requests'       => array(
-						'event' => admin_url( 'admin-ajax.php' ),
-					),
-					'triggers'       => array(
-						'trackPageview' => array(
-							'on'      => 'visible',
-							'request' => 'event',
-							'vars'    => array(
-								'eventId' => 'pageview',
-							),
-						),
-					),
-					'transport'      => array(
-						'xhrpost' => true,
-					),
-				),
+				'config_data' => self::make_amp_config(),
 			);
 		}
 
 		return $analytics;
+	}
+
+	/**
+	 * Generate AMP-analytics configuration.
+	 *
+	 * @return array Configuration array.
+	 */
+	private static function make_amp_config() {
+		return array(
+			'requests'       => array(
+				'pageview' => admin_url( 'admin-ajax.php' ),
+			),
+			'extraUrlParams' => array(
+				'action'           => 'statify_track',
+				'_ajax_nonce'      => wp_create_nonce( 'statify_track' ),
+				'statify_referrer' => '${documentReferrer}',
+				'statify_target'   => '${canonicalPath}amp/',
+			),
+			'triggers'       => array(
+				'trackPageview' => array(
+					'on'      => 'visible',
+					'request' => 'pageview',
+				),
+			),
+		);
 	}
 }

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -374,8 +374,12 @@ class Statify_Frontend extends Statify {
 	 * @version  1.4.1
 	 */
 	public static function wp_footer() {
-		// Skip by option.
-		if ( ! self::is_javascript_tracking_enabled() ) {
+		// JS tracking disabled or AMP is used for the current request.
+		if (
+			! self::is_javascript_tracking_enabled() ||
+			( function_exists( 'amp_is_request' ) && amp_is_request() ) ||
+			( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() )
+		) {
 			return;
 		}
 

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -80,7 +80,8 @@ class Statify {
 			add_action( 'template_redirect', array( 'Statify_Frontend', 'track_visit' ) );
 			add_filter( 'query_vars', array( 'Statify_Frontend', 'query_vars' ) );
 			add_action( 'wp_footer', array( 'Statify_Frontend', 'wp_footer' ) );
-			if ( function_exists( 'is_amp_endpoint' ) ) { // Automattic AMP plugin present.
+			if ( function_exists( 'amp_is_request' ) || function_exists( 'is_amp_endpoint' ) ) {
+				// Automattic AMP plugin present.
 				add_filter( 'amp_analytics_entries', array( 'Statify_Frontend', 'amp_analytics_entries' ) );
 				add_filter( 'amp_post_template_analytics', array( 'Statify_Frontend', 'amp_post_template_analytics' ) );
 			}

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -81,6 +81,7 @@ class Statify {
 			add_filter( 'query_vars', array( 'Statify_Frontend', 'query_vars' ) );
 			add_action( 'wp_footer', array( 'Statify_Frontend', 'wp_footer' ) );
 			if ( function_exists( 'is_amp_endpoint' ) ) { // Automattic AMP plugin present.
+				add_filter( 'amp_analytics_entries', array( 'Statify_Frontend', 'amp_analytics_entries' ) );
 				add_filter( 'amp_post_template_analytics', array( 'Statify_Frontend', 'amp_post_template_analytics' ) );
 			}
 		}


### PR DESCRIPTION
Standard and Transitional mode use the `amp_analytics_entries` hook, Reader mode uses `amp_post_template_analytics`.
We only added a filter for the latter, so AMP compatibility was only available in Reader mode.