### PR TITLE
exclude sitemap calls from tracking (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 * Fix AMP compatiblity for Standard and Transitional mode (#181) (#182)
 * JavaScript is no longer embedded if request is served by AMP (#181) (#182)
 * Always register the action for the cleanup (#184)
+* Exclude sitemap calls (WP 5.5) from tracking (#185) (#186)
 
 ## 1.8.0
 * Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -252,9 +252,11 @@ class Statify_Frontend extends Statify {
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */
 	private static function _is_internal() {
-		// Skip for preview, 404 calls, feed, search and favicon access.
+		global $wp_query;
+		// Skip for preview, 404 calls, feed, search, favicon and sitemap access.
 		return is_preview() || is_404() || is_feed() || is_search()
-			|| ( function_exists( 'is_favicon' ) && is_favicon() );
+			|| ( function_exists( 'is_favicon' ) && is_favicon() )
+			|| '' !== get_query_var( 'sitemap' ) || '' !== get_query_var( 'sitemap-stylesheet' );
 	}
 
 	/**

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -252,7 +252,6 @@ class Statify_Frontend extends Statify {
 	 * @return   boolean  $skip_hook  TRUE if NO tracking is desired
 	 */
 	private static function _is_internal() {
-		global $wp_query;
 		// Skip for preview, 404 calls, feed, search, favicon and sitemap access.
 		return is_preview() || is_404() || is_feed() || is_search()
 			|| ( function_exists( 'is_favicon' ) && is_favicon() )

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -121,6 +121,7 @@ class Test_Tracking extends WP_UnitTestCase {
 	public function test_skip_tracking() {
 		global $_SERVER;
 		global $wp_query;
+		global $wp_version;
 
 		// Initialize Statify with default configuration: no JS tracking, no logged-in users.
 		$this->init_statify_tracking();

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -169,6 +169,19 @@ class Test_Tracking extends WP_UnitTestCase {
 			$this->assertNull( $stats, 'Favicons should not be tracked.' );
 			$wp_query->is_favicon = false;
 		}
+
+		// Sitemap XML and XSL for WP 5.5 and above.
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			set_query_var( 'sitemap', 'index' );
+			Statify_Frontend::track_visit();
+			$stats = $this->get_stats();
+			$this->assertNull( $stats, 'Sitemap XML should not be tracked.' );
+			set_query_var( 'sitemap', null );
+			set_query_var( 'sitemap-stylesheet', 'sitemap' );
+			Statify_Frontend::track_visit();
+			$stats = $this->get_stats();
+			$this->assertNull( $stats, 'Sitemap XSL should not be tracked.' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
resolves #185

The default tracking method does not detect core sitemap calls to _wp-sitemap.xml_, because there is no check. When WP core sitemaps are disabled, the `redirect_template` hook is too early, i.e. the sitemap does not yet know if it shall be generated or skipped, so we accidentally track 404 hits in this case.

JS tracking does not seem to be affected, because there either is no `wo_footer()` for the XML output or `is_404()` returns `true` at this point.

**Solution:**
Add a check for the query variable `sitemap` as suggested in the WP Core discussion<sup>[1](#fn1)</sup> to the `_is_internal()` check, s.t. we never try to track anything for sitemap calls.

----
<a name="fn1">[1]</a> https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/#comment-39484

