### PR TITLE
declare compatibility with WP 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 * Fix AMP compatiblity for Standard and Transitional mode (#181) (#182)
 * JavaScript is no longer embedded if request is served by AMP (#181) (#182)
 * Always register the action for the cleanup (#184)
+* Tested up to WordPress 5.6
 
 ## 1.8.0
 * Fix date offset in dashboard widget in WP 5.3+ environments with mixed timezones (#167)

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
-* Tested up to:      5.5
+* Tested up to:      5.6
 * Requires PHP:      5.2
 * Stable tag:        1.8.0
 * License:           GPLv3 or later


### PR DESCRIPTION
resolves #188 

Installed latest 1.8.1 development version on WP 5.6-RC4-49756 using PHP 8.0.0(*) with `WP_DEBUG` enabled.
* tracking works fine in default and JS mode.
* widget is displayed correctly and controls are working as expected (so no jQuery issues)
* hooks are fired
* no errors, warnings or notices raised

Same test on Multisite with same versions.


(*) project does not yet support PHP 8 as build environment, but it's fine for runtime