### PR TITLE
add "?amp" instead of "/amp/" for AMP visit tracking (#183)

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -163,7 +163,7 @@ class Statify_Frontend extends Statify {
 			),
 			'extraUrlParams' => array(
 				'referrer' => '${documentReferrer}',
-				'target'   => '${canonicalPath}amp/',
+				'target'   => '${canonicalPath}?amp',
 			),
 			'triggers'       => array(
 				'trackPageview' => array(

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -135,9 +135,15 @@ class Statify {
 		/* Global vars */
 		global $wp_rewrite;
 
-		// Trim target URL.
+		// Trim target URL, i.e. remove query parameters..
 		if ( $wp_rewrite->permalink_structure ) {
-			$target = wp_parse_url( $target, PHP_URL_PATH );
+			$parsed_target = wp_parse_url( $target );
+			$target = isset( $parsed_target['path'] ) ? $parsed_target['path'] : null;
+
+			// Re-add AMP parameter to preserve that information (only applicable for JS tracking).
+			if ( isset( $parsed_target['query'] ) && 'amp/' === $parsed_target['query'] ) {
+				add_query_arg( 'amp', '', $target );
+			}
 		}
 
 		// Init rows.


### PR DESCRIPTION
This is one possible way to fix #183 

Instead of adding ` /amp/`  to the URL of the page is accessed via AMP, we now add ` ?amp` .
This is always fine, because AMP should never provide other URL parameters.

Depending on the outcome of the discussion in #183 we can either merge this PR or close it. Just opened, so we don't do the work twice if needed.