### PR TITLE
adjust dashboard widget colors to WP 5.7 palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.8.2
+* Minor color adjustments for the dashboard widget (#197)
+* Tested up to WordPress 5.7
+
 ## 1.8.1
 * Fix AMP compatibility for Standard and Transitional mode (#181) (#182)
 * JavaScript is no longer embedded if request is served by AMP (#181) (#182)

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,7 +1,7 @@
 /* @group Front page */
 
 #statify_chart {
-	color: #aaa;
+	color: #a7aaad;
 	direction: rtl;
 	height: 140px;
 	margin: 0 -4px;
@@ -23,18 +23,18 @@
 }
 
 #statify_chart .ct-line {
-	stroke: #0074a2;
+	stroke: #3582c4;
 	stroke-width: 2px;
 }
 
 #statify_chart .ct-point {
 	fill: #fff;
-	stroke: #0074a2;
+	stroke: #3582c4;
 	stroke-width: 1.5px;
 }
 
 #statify_chart .ct-area {
-	fill: #0074a2;
+	fill: #3582c4;
 }
 
 .statify-chartist-tooltip {
@@ -49,7 +49,7 @@
 }
 
 .statify-chartist-tooltip .chartist-tooltip-meta {
-	color: #0074a2;
+	color: #3582c4;
 }
 
 #statify_dashboard .postbox-title-action a,
@@ -72,7 +72,7 @@
 }
 
 #statify_dashboard .table p.sub {
-	color: #bbb;
+	color: #646970;
 	margin: 0 0 -4px;
 }
 
@@ -104,7 +104,7 @@
 #statify_dashboard td.b {
 	text-align: right;
 	padding-right: 4px;
-	color: #777;
+	color: #646970;
 }
 
 #statify_dashboard label {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
-* Tested up to:      5.6
+* Tested up to:      5.7
 * Requires PHP:      5.2
 * Stable tag:        1.8.1
 * License:           GPLv3 or later

--- a/statify.php
+++ b/statify.php
@@ -7,7 +7,7 @@
  * Author URI:  https://pluginkollektiv.org
  * Plugin URI:  https://wordpress.org/plugins/statify/
  * License:     GPLv3 or later
- * Version:     1.8.1
+ * Version:     1.8.2
  *
  * @package WordPress
  */
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'STATIFY_FILE', __FILE__ );
 define( 'STATIFY_DIR', dirname( __FILE__ ) );
 define( 'STATIFY_BASE', plugin_basename( __FILE__ ) );
-define( 'STATIFY_VERSION', '1.8.1' );
+define( 'STATIFY_VERSION', '1.8.2' );
 
 
 /* Hooks */


### PR DESCRIPTION
WordPress 5.7 features an updated color palette for the admin UI (https://make.wordpress.org/core/2021/02/23/standardization-of-wp-admin-colors-in-wordpress-5-7/)

This PR updates the dashboard colors from
`#0074a2` to `#3582c4` (Blue 40),
`#aaaaaa` to `#a7aaad` (Gray 20) and
`#bbbbbb` / `#777777` to `#646970` (Gray 50)

The latter slightly larger difference was intentional for increased readability of the widget texts.

![statify_wp57color](https://user-images.githubusercontent.com/12963621/110163233-19003880-7df0-11eb-96f5-e65662f87ff0.png)
(Screenshot from WP 5.7 RC2, left old, right new colors)

----

Also tested the changes in an actual 5.7 instance without any issues, so the compatibility was updated.