### PR TITLE
Use full width for total to avoid line break

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -93,7 +93,6 @@
 #statify_dashboard .table.total {
 	clear: both;
 	float: left;
-	width: 45%;
 }
 
 #statify_dashboard td {


### PR DESCRIPTION
Avoids the line break for long dates ("since Monday, 7. September 2020" as in the screenshot of #197) in the dashboard.