### PR TITLE
use CSS flex and full width for totals in dashboard widget

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -2,13 +2,13 @@
 
 #statify_chart {
 	color: #a7aaad;
+	flex: 0 0 100%;
 	direction: rtl;
 	height: 140px;
 	margin: 0 -4px;
 	overflow-x: auto;
 	overflow-y: hidden;
 	text-align: center;
-	width: 100%;
 }
 
 #statify_chart_data {
@@ -60,6 +60,8 @@
 }
 
 #statify_dashboard .inside {
+	display: flex;
+	flex-wrap: wrap;
 	height: 1%;
 	margin: 0;
 	padding-bottom: 0;
@@ -80,20 +82,13 @@
 	overflow: hidden;
 }
 
-#statify_dashboard .table.referrer {
-	float: left;
-	width: 45%;
-}
-
+#statify_dashboard .table.referrer,
 #statify_dashboard .table.target {
-	float: right;
-	width: 55%;
+	flex: 1 0 50%;
 }
 
 #statify_dashboard .table.total {
-	clear: both;
-	float: left;
-	width: 45%;
+	flex: 0 0 100%;
 }
 
 #statify_dashboard td {
@@ -118,6 +113,7 @@
 /* @group Back stage */
 
 #statify_dashboard form {
+	flex: 0 0 100%;
 	padding: 18px 0;
 }
 

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -113,7 +113,7 @@ $stats = Statify_Dashboard::get_stats( $refresh ); ?>
 	</div>
 <?php } ?>
 
-<form method="post" class="clear">
+<form method="post">
 	<?php wp_nonce_field( 'statify-dashboard-refresh' ); ?>
 	<button class="button button-primary" name="statify-fresh"><?php esc_html_e( 'Refresh', 'statify' ); ?></button>
 </form>


### PR DESCRIPTION
Alternative solution for #198

Intention was to use the full widget width for the totals display. This PR rewrites the CSS to use `flex` instead of `float` that also has the benefit of breaking down to single-column layout on _really_ small screens or really long URLs in the top lists while the current solution does not.

Also works in IE 11 (despite the big warning above :see_no_evil: )