### PR TITLE
Update links to documentation (website instead of wordpress.org)

### DIFF
--- a/statify.php
+++ b/statify.php
@@ -4,8 +4,8 @@
  * Description: Compact, easy-to-use and privacy-compliant stats plugin for WordPress.
  * Text Domain: statify
  * Author:      pluginkollektiv
- * Author URI:  https://pluginkollektiv.org
- * Plugin URI:  https://wordpress.org/plugins/statify/
+ * Author URI:  https://pluginkollektiv.org/
+ * Plugin URI:  https://statify.pluginkollektiv.org/
  * License:     GPLv3 or later
  * Version:     1.8.2
  *

--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -46,7 +46,7 @@ class_exists( 'Statify' ) || exit; ?>
 <?php wp_nonce_field( 'statify-dashboard' ); ?>
 
 <p class="meta-links">
-	<a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/statify/', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Documentation', 'statify' ); ?></a>
+	<a href="<?php echo esc_url( __( 'https://statify.pluginkollektiv.org/', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Documentation', 'statify' ); ?></a>
 	&bull; <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'statify' ); ?></a>
 	&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/support/plugin/statify', 'statify' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'statify' ); ?></a>
 </p>


### PR DESCRIPTION
We published the Statify documentation on https://statify.pluginkollektiv.org/ - so let's link the Statify website in the plugin.