### PR TITLE
remove double closing tag on value attribute of radio buttons

### DIFF
--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -158,7 +158,7 @@ class Statify_Settings {
 	private static function show_snippet_option( $value, $label ) {
 		?>
 			<label>
-				<input name="statify[snippet]" type="radio" value="<?php echo esc_html( $value ); ?>>" <?php checked( Statify::$_options['snippet'], $value ); ?>>
+				<input name="statify[snippet]" type="radio" value="<?php echo esc_html( $value ); ?>" <?php checked( Statify::$_options['snippet'], $value ); ?>>
 				<?php echo esc_html( $label ); ?>
 			</label>
 		<?php


### PR DESCRIPTION
Radio buttons in the settings form, i.e. selector for JS tracking mode contains a superfluous `>` character in the value attribute because of doubled closing tag after the PHP sequence.
```html
<input name="statify[snippet]" type="radio" value="0>">
                                                    ^
----------------------------------------------------|
```