### PR TITLE
Declares multisite init_site methods as static

### DIFF
--- a/inc/class-statify-install.php
+++ b/inc/class-statify-install.php
@@ -53,7 +53,7 @@ class Statify_Install {
 	 *
 	 * @param int $site_id Site ID.
 	 */
-	public function init_site( $site_id ) {
+	public static function init_site( $site_id ) {
 
 		switch_to_blog( (int) $site_id );
 

--- a/inc/class-statify-uninstall.php
+++ b/inc/class-statify-uninstall.php
@@ -50,7 +50,7 @@ class Statify_Uninstall {
 	 *
 	 * @param int $site_id Site ID.
 	 */
-	public function init_site( $site_id ) {
+	public static function init_site( $site_id ) {
 
 		switch_to_blog( $site_id );
 


### PR DESCRIPTION
In a multisite setup on PHP 8 initialisation methods cause a fatal error when adding/deleting a site. Declaring these methods as static fixes the problem.

`Fatal error: Uncaught TypeError: call_user_func_array(): Argument #1 ($function) must be a valid callback, non-static method Statify_Install::init_site() cannot be called statically`