### PR TITLE
ci: run tests against "latest" and "nightly" WP version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ jobs:
           - php: '7.4'
             wordpress: '5.5'
           - php: '8.0'
-            wordpress: '5.8-RC4'
+            wordpress: 'latest'
+          - php: '8.0'
+            wordpress: 'nightly'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Keep older stacks like PHP/WP 5.6/4.7 and 7.4/5.5 as fixed marks, but replace the 8.0/5.8 with 8.0/latest.

Also add 8.0/nightly step which might possibly fail, but gives a hint on compatibility with upcoming releases. The latter should not be added as mandatory check though.