### PR TITLE
use same date retrieval for tracking and analysis (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+* Use same date retrieval for tracking and analysis (#227) (#232)
+
 ## 1.8.3
 * Update documentation links (#204)
 * Minor markup fix on settings page (#206)

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -82,7 +82,7 @@ class Statify_Frontend extends Statify {
 		);
 
 		// Set request timestamp.
-		$data['created'] = strftime( '%Y-%m-%d', current_time( 'timestamp' ) );
+		$data['created'] = current_time( 'Y-m-d' );
 
 		$needles = array( home_url(), network_admin_url() );
 


### PR DESCRIPTION
We use "WP timestamp" in combination with strftime in the tracking
routine and retrieve WP Time in "Y-m-d" format for retrieval in the
dashboard logic. While it is discouraged to work with "WP Timestamps"
and strftime is deprecated as of PHP 8.1, is makes sense to use the same
source of time on both ends.

The present logic is not inherently wrong. The "WP timestmap" is
basically a unix timestamp with zone offeset already calculated and
parsing the result yields a local time value shifted to GMT. Zone is not
part of the output here, so it's effectively the same as Y-m-d local
date.

We not use the current time in Y-m-d notation on both ends without
breaking or invalidating the present logic.