### PR TITLE
introduce data aggregation (#194)

### DIFF
--- a/inc/class-statify-cron.php
+++ b/inc/class-statify-cron.php
@@ -23,13 +23,12 @@ class Statify_Cron extends Statify {
 	 *
 	 * @since    0.3.0
 	 * @version  1.4.0
+	 * @wp-hook boolean  statify__skip_aggregation
 	 */
 	public static function cleanup_data() {
-
-		// Global.
 		global $wpdb;
 
-		// Remove items.
+		// Remove old items.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM `$wpdb->statify` WHERE created <= SUBDATE(%s, %d)",
@@ -38,13 +37,13 @@ class Statify_Cron extends Statify {
 			)
 		);
 
-		// Aggregate.
-		self::aggregate_data();
+		// Aggregate data.
+		if ( ! apply_filters( 'statify__skip_aggregation', false ) ) {
+			self::aggregate_data();
+		}
 
 		// Optimize DB.
-		$wpdb->query(
-			"OPTIMIZE TABLE `$wpdb->statify`"
-		);
+		$wpdb->query( "OPTIMIZE TABLE `$wpdb->statify`" );
 	}
 
 	/**

--- a/inc/class-statify-cron.php
+++ b/inc/class-statify-cron.php
@@ -38,9 +38,75 @@ class Statify_Cron extends Statify {
 			)
 		);
 
+		// Aggregate.
+		self::aggregate_data();
+
 		// Optimize DB.
 		$wpdb->query(
 			"OPTIMIZE TABLE `$wpdb->statify`"
 		);
+	}
+
+	/**
+	 * Aggregate data in database.
+	 *
+	 * @since 1.9
+	 */
+	public static function aggregate_data() {
+		global $wpdb;
+
+		// Get date of last aggregation.
+		if ( isset( self::$_options['last_aggregation'] ) ) {
+			// Value saved, use it.
+			$start = self::$_options['last_aggregation'];
+		} else {
+			// No? We need to clean up all data. Let's determine the oldest data in the database.
+			$start = $wpdb->get_col( "SELECT MIN(`created`) FROM `$wpdb->statify`" );
+			$start = $start[0];
+		}
+
+		if ( is_null( $start ) ) {
+			// No data available, i.e not cleaned up yet and no data in database.
+			return;
+		}
+
+		$now  = new DateTime();
+		$date = new DateTime( $start );
+
+		// Iterate over every day from start (inclusive) til now.
+		while ( $date < $now ) {
+			$agg = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT `created`, `referrer`, `target`, SUM(`hits`) as `hits` FROM `$wpdb->statify` WHERE `created` = %s GROUP BY `created`, `referrer`, `target`",
+					$date->format( 'Y-m-d' )
+				),
+				ARRAY_A
+			);
+
+			// Remove non-aggregated data and insert aggregates within one transaction.
+			$wpdb->query( 'START TRANSACTION' );
+			$res = $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM `$wpdb->statify` WHERE `created` = %s",
+					$date->format( 'Y-m-d' )
+				)
+			);
+			if ( false !== $res ) {
+				foreach ( $agg as $a ) {
+					if ( false === $wpdb->insert( $wpdb->statify, $a ) ) {
+						$wpdb->query( 'ROLLBACK' );
+						break;
+					}
+				}
+			}
+			$wpdb->query( 'COMMIT' );
+
+			// Continue with next day.
+			$date->modify( '+1 day' );
+		}
+
+		// Remember last aggregation date.
+		self::$_options['last_aggregation'] = $now->format( 'Y-m-d' );
+		update_option( 'statify', self::$_options );
 	}
 }

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -322,7 +322,7 @@ class Statify_Dashboard extends Statify {
 		$data = array(
 			'visits'   => $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT `created` as `date`, COUNT(`created`) as `count` FROM `$wpdb->statify` GROUP BY `created` ORDER BY `created` DESC LIMIT %d",
+					"SELECT `created` as `date`, SUM(`hits`) as `count` FROM `$wpdb->statify` GROUP BY `created` ORDER BY `created` DESC LIMIT %d",
 					$days_show
 				),
 				ARRAY_A
@@ -332,7 +332,7 @@ class Statify_Dashboard extends Statify {
 		if ( $today ) {
 			$data['target'] = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT COUNT(`target`) as `count`, `target` as `url` FROM `$wpdb->statify` WHERE created = %s GROUP BY `target` ORDER BY `count` DESC, `url` ASC LIMIT %d",
+					"SELECT SUM(`hits`) as `count`, `target` as `url` FROM `$wpdb->statify` WHERE created = %s GROUP BY `target` ORDER BY `count` DESC, `url` ASC LIMIT %d",
 					$current_date,
 					$limit
 				),
@@ -340,7 +340,7 @@ class Statify_Dashboard extends Statify {
 			);
 			$data['referrer'] = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT COUNT(`referrer`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created = %s GROUP BY `host` ORDER BY `count` DESC, `url` ASC LIMIT %d",
+					"SELECT SUM(`hits`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created = %s GROUP BY `host` ORDER BY `count` DESC, `url` ASC LIMIT %d",
 					$current_date,
 					$limit
 				),
@@ -349,7 +349,7 @@ class Statify_Dashboard extends Statify {
 		} else {
 			$data['target'] = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT COUNT(`target`) as `count`, `target` as `url` FROM `$wpdb->statify` WHERE created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `target` ORDER BY `count` DESC, `url` ASC LIMIT %d",
+					"SELECT SUM(`hits`) as `count`, `target` as `url` FROM `$wpdb->statify` WHERE created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `target` ORDER BY `count` DESC, `url` ASC LIMIT %d",
 					$current_date,
 					$days_show,
 					$limit
@@ -358,7 +358,7 @@ class Statify_Dashboard extends Statify {
 			);
 			$data['referrer'] = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT COUNT(`referrer`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `host` ORDER BY `count` DESC, `url` ASC LIMIT %d",
+					"SELECT SUM(`hits`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `host` ORDER BY `count` DESC, `url` ASC LIMIT %d",
 					$current_date,
 					$days_show,
 					$limit
@@ -371,12 +371,12 @@ class Statify_Dashboard extends Statify {
 			$data['visit_totals'] = array(
 				'today'           => $wpdb->get_var(
 					$wpdb->prepare(
-						"SELECT COUNT(`created`) FROM `$wpdb->statify` WHERE created = %s",
+						"SELECT SUM(`hits`) FROM `$wpdb->statify` WHERE created = %s",
 						$current_date
 					)
 				),
 				'since_beginning' => $wpdb->get_row(
-					"SELECT COUNT(`created`) AS `count`, MIN(`created`) AS `date` FROM `$wpdb->statify`",
+					"SELECT SUM(`hits`) AS `count`, MIN(`created`) AS `date` FROM `$wpdb->statify`",
 					ARRAY_A
 				),
 			);

--- a/inc/class-statify-table.php
+++ b/inc/class-statify-table.php
@@ -47,7 +47,6 @@ class Statify_Table {
 	 * @version 1.2.4
 	 */
 	public static function create() {
-
 		global $wpdb;
 
 		// If existent.
@@ -65,6 +64,7 @@ class Statify_Table {
 			  `created` date NOT NULL default '0000-00-00',
 			  `referrer` varchar(255) NOT NULL default '',
 			  `target` varchar(255) NOT NULL default '',
+			  `hits` integer NOT NULL default 1,
 			  PRIMARY KEY  (`id`),
 			  KEY `referrer` (`referrer`),
 			  KEY `target` (`target`),

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -147,6 +147,7 @@ class Statify {
 			'created'  => current_time( 'Y-m-d' ),
 			'referrer' => $referrer,
 			'target'   => $target,
+			'hits'     => 1,
 		);
 
 		// Insert.

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -29,6 +29,8 @@ class Test_Cron extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_cronjob() {
+		global $wpdb;
+
 		// Initialize normal cycle, configure storage period of 3 days.
 		$this->init_statify_widget( 3 );
 		$this->assertNotFalse(
@@ -61,7 +63,8 @@ class Test_Cron extends WP_UnitTestCase {
 			$this->assertEquals( 2, $v['count'], 'Unexpected visit count' );
 		}
 
-		// Run the cron job.
+		// Run the cron job without aggregation.
+		add_filter( 'statify__skip_aggregation', '__return_true' );
 		Statify_Cron::cleanup_data();
 
 		// Verify that 2 days have been deleted.
@@ -72,6 +75,20 @@ class Test_Cron extends WP_UnitTestCase {
 			$this->assertContains( $v['date'], $remaining_dates, 'Unexpected remaining date in stats' );
 			$this->assertEquals( 2, $v['count'], 'Unexpected visit count' );
 		}
+		$this->assertEquals(
+			6,
+			$wpdb->get_var( "SELECT COUNT(*) FROM `$wpdb->statify`" ),
+			'Unexpected number of entries after cleanup without aggregation'
+		);
+
+		// Run the cron job with aggregation (default).
+		remove_filter( 'statify__skip_aggregation', '__return_true' );
+		Statify_Cron::cleanup_data();
+		$this->assertEquals(
+			3,
+			$wpdb->get_var( "SELECT COUNT(*) FROM `$wpdb->statify`" ),
+			'Unexpected number of entries after cleanup with aggregation'
+		);
 	}
 
 	/**

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -361,10 +361,11 @@ class Test_Tracking extends WP_UnitTestCase {
 		$this->assertNotNull( $stats['visits'][0]['count'], 'Request not tracked' );
 		$this->assertNotEmpty( $capture, 'Hook stativy__visit_saved has not fired' );
 		$this->assertTrue( is_numeric( $capture['id'] ) && $capture['id'] > 0, 'unexpected entry ID' );
-		$this->assertCount( 3, $capture['data'], 'unexpected number of data fields' );
+		$this->assertCount( 4, $capture['data'], 'unexpected number of data fields' );
 		$this->assertEquals( ( new DateTime() )->format( 'Y-m-d' ), $capture['data']['created'], 'unexpected creation date' );
 		$this->assertEquals( 'https://statify.pluginkollektiv.org/', $capture['data']['referrer'], 'unexpected referrer' );
 		$this->assertEquals( '/page', $capture['data']['target'], 'unexpected target' );
+		$this->assertEquals( 1, $capture['data']['hits'], 'unexpected hits' );
 	}
 
 	/**


### PR DESCRIPTION
We add a new column named `hits` to the database table with default value of 1.
The tracking routine is preserved as is, i.e. it will insert a single row per hit.

The cleanup routine (cron job) is extended with an aggregation function that walks through the database and groups distinct date/referrer/target combinations with the sum of all hits.

*before:*
| created    | referrer            | target | hits |
| ---------- | ------------------- | ------ | ---- |
| 2022-09-07 | example.com         | /      | 1    |
| 2022-09-07 | pluginkollektiv.org | /test/ | 1    |
| 2022-09-07 | example.com         | /      | 1    |
| 2022-09-07 | example.com         | /      | 1    |
| 2022-09-08 | pluginkollektiv.org | /test/ | 1    |
| 2022-09-08 | pluginkollektiv.org | /      | 1    |

*after:*
| created    | referrer            | target | hits |
| ---------- | ------------------- | ------ | ---- |
| 2022-09-07 | example.com         | /      | 3    |
| 2022-09-07 | pluginkollektiv.org | /test/ | 1    |
| 2022-09-08 | pluginkollektiv.org | /test/ | 1    |
| 2022-09-08 | pluginkollektiv.org | /      | 1    |

The output is generated from `SUM(hits)` instead of `COUNT(*)` then.

We also introduce a boolean book `statify__skip_aggregation` (defaults to `false`) to keep the previous behavior and disable the new aggregation.

This might be necessary if the inserted entry is extended with custom columns, e.g. in a `statify__visit_saved` hook. If this is the case, aggregation will fail, because we don't know about additional columns. We could of course add another hook for custom aggregation columns and dynamically build up the statements, but for most users this won't be necessary and it can be extended in future releases as well.