### PR TITLE
clean up HTML markup for dashboard widget

### DIFF
--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -22,27 +22,27 @@ class_exists( 'Statify' ) || exit; ?>
 <?php endif; ?>
 
 <h3><?php esc_html_e( 'Widget Settings', 'statify' ); ?></h3>
-<fieldset>
-	<label for="statify_days_show">
-		<input name="statify[days_show]" id="statify_days_show" type="number" min="1"
+<div>
+	<label>
+		<input name="statify[days_show]" type="number" min="1"
 			   value="<?php echo esc_attr( Statify::$_options['days_show'] ); ?>">
 		<?php esc_html_e( 'days', 'statify' ); ?> -
 		<?php esc_html_e( 'Period of data display in Dashboard', 'statify' ); ?>
 	</label>
-	<label for="statify_limit">
-		<input name="statify[limit]" id="statify_limit" type="number" min="1" max="100"
+	<label>
+		<input name="statify[limit]" type="number" min="1" max="100"
 			   value="<?php echo esc_attr( Statify::$_options['limit'] ); ?>">
 		<?php esc_html_e( 'Number of entries in top lists', 'statify' ); ?>
 	</label>
-	<label for="statify_today">
-		<input type="checkbox" name="statify[today]" id="statify_today" value="1" <?php checked( Statify::$_options['today'], 1 ); ?> />
+	<label>
+		<input type="checkbox" name="statify[today]" value="1" <?php checked( Statify::$_options['today'], 1 ); ?>>
 		<?php esc_html_e( 'Entries in top lists only for today', 'statify' ); ?>
 	</label>
-	<label for="statify_show_totals">
-		<input type="checkbox" name="statify[show_totals]" id="statify_show_totals" value="1" <?php checked( Statify::$_options['show_totals'], 1 ); ?> />
+	<label>
+		<input type="checkbox" name="statify[show_totals]" value="1" <?php checked( Statify::$_options['show_totals'], 1 ); ?>>
 		<?php esc_html_e( 'Show totals', 'statify' ); ?>
 	</label>
-</fieldset>
+</div>
 <?php wp_nonce_field( 'statify-dashboard' ); ?>
 
 <p class="meta-links">

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -113,5 +113,5 @@ $stats = Statify_Dashboard::get_stats( $refresh ); ?>
 
 <form method="post">
 	<?php wp_nonce_field( 'statify-dashboard-refresh' ); ?>
-	<button class="button button-primary" name="statify-fresh"><?php esc_html_e( 'Refresh', 'statify' ); ?></button>
+	<button type="submit" class="button button-primary" name="statify-fresh"><?php esc_html_e( 'Refresh', 'statify' ); ?></button>
 </form>


### PR DESCRIPTION
* remove redundant for/id attributes from wrapped `<label>` tags
  The `<input` elements are are wrapped `<label>`, so the association is clear and no for/id mapping is required.
* use _<div>_ instead of _<fieldset>_ as wrapper around settings
  For valid HTML the `<fieldset>` should have a `<legend>` element. We might move the headline (`<h3>`) into the legend, but actually we only have one set of fields in the form, so additional semantic grouping is not necessary.
* do not close <input> tags
  We close the tags for number inputs, but not for checkboxes. Let's use the same way for all inputs.
* add type attribute to refresh button
  Type attribute is required. All browsers tested seem to assume "submit" by default (otherwise the mechanism would not work), but we should make it explicit.