### PR TITLE
extend options to allow skipping only administrators (#229)

### DIFF
--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -323,9 +323,13 @@ class Statify_Settings {
 	 */
 	public static function options_skip_logged_in() {
 		?>
-		<input id="statify-skip-logged_in" type="checkbox" name="statify[skip][logged_in]" value="1"<?php checked( Statify::$_options['skip']['logged_in'] ); ?>>
-		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
-		<p class="description"><?php esc_html_e( 'Enabling this option excludes any views of logged-in users from tracking.', 'statify' ); ?></p>
+		<select id="statify-skip-logged_in" name="statify[skip][logged_in]">
+			<option value="0" <?php selected( Statify::$_options['skip']['logged_in'], 0 ); ?>><?php esc_html_e( 'Track all users', 'statify' ); ?></option>
+			<option value="1" <?php selected( Statify::$_options['skip']['logged_in'], 1 ); ?>><?php esc_html_e( 'Skip all users', 'statify' ); ?></option>
+			<option value="2" <?php selected( Statify::$_options['skip']['logged_in'], 2 ); ?>><?php esc_html_e( 'Skip administrators', 'statify' ); ?></option>
+		</select>
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Skip all users', 'statify' ); ?>)
+		<p class="description"><?php esc_html_e( 'This option specified whether logged-in users and/or administrators should be excluded from tracking.', 'statify' ); ?></p>
 		<?php
 	}
 
@@ -393,7 +397,21 @@ class Statify_Settings {
 		foreach ( array( 'today', 'blacklist', 'show_totals' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
-		$res['skip']['logged_in'] = isset( $options['skip']['logged_in'] ) && 1 === (int) $options['skip']['logged_in'] ? 1 : 0;
+
+		if ( isset( $options['skip']['logged_in'] ) ) {
+			$skip_logged_in = (int) $options['skip']['logged_in'];
+			if ( in_array(
+				$skip_logged_in,
+				array(
+					Statify::SKIP_USERS_NONE,
+					Statify::SKIP_USERS_ALL,
+					Statify::SKIP_USERS_ADMIN,
+				),
+				true
+			) ) {
+				$res['skip']['logged_in'] = $skip_logged_in;
+			}
+		}
 
 		// Sanitize user roles.
 		$res['show_widget_roles'] = array();

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -21,6 +21,10 @@ class Statify {
 	const TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK = 1;
 	const TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK = 2;
 
+	const SKIP_USERS_NONE = 0;
+	const SKIP_USERS_ALL = 1;
+	const SKIP_USERS_ADMIN = 2;
+
 	/**
 	 * Plugin options.
 	 *
@@ -56,7 +60,7 @@ class Statify {
 				'show_totals'       => 0,
 				'show_widget_roles' => null, // Just for documentation, the default is calculated later.
 				'skip'              => array(
-					'logged_in' => 1,
+					'logged_in' => self::SKIP_USERS_ALL,
 				),
 			)
 		);
@@ -265,7 +269,9 @@ class Statify {
 		}
 
 		// Skip logged in users, if enabled.
-		if ( self::$_options['skip']['logged_in'] && is_user_logged_in() ) {
+		if ( self::SKIP_USERS_ALL === self::$_options['skip']['logged_in'] && is_user_logged_in() ||
+			// Only skip administrators.
+			self::SKIP_USERS_ADMIN === self::$_options['skip']['logged_in'] && current_user_can( 'manage_options' ) ) {
 			return true;
 		}
 

--- a/tests/trait-statify-test-support.php
+++ b/tests/trait-statify-test-support.php
@@ -14,16 +14,16 @@ trait Statify_Test_Support {
 	/**
 	 * Initialize Statify.
 	 *
-	 * @param integer $method          Configure tracking method (default: 0).
-	 * @param boolean $track_logged_in Configure tracking for logged-in users (default: false).
-	 * @param boolean $blacklist       Configure blacklist usage (default: false).
+	 * @param integer $method         Configure tracking method (default: 0).
+	 * @param integer $skip_logged_in Configure tracking for logged-in users (default: 1).
+	 * @param boolean $blacklist      Configure blacklist usage (default: false).
 	 */
-	protected function init_statify_tracking( $method = 0, $track_logged_in = false, $blacklist = false ) {
+	protected function init_statify_tracking( $method = 0, $skip_logged_in = 1, $blacklist = false ) {
 		$this->init_statify(
 			array(
 				'snippet'   => $method,
 				'skip'      => array(
-					'logged_in' => $track_logged_in ? 0 : 1,
+					'logged_in' => $skip_logged_in,
 				),
 				'blacklist' => $blacklist ? 1 : 0,
 			)


### PR DESCRIPTION
resolves #229 

The current option to skip logged-in users is extended with another possible value to exclude administrators (users who can manage options), but track regular users' visits.

The checkbox option is extended to a select-box with 3 possible options. Current internal config structure (0 = track users, 1 = exclude users) remains fully compatible while new value (2) represents "skip administrators".