### PR TITLE
replace FILTER_SANITIZE_STRING with sanitize_text_field

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -181,10 +181,7 @@ class Statify_Frontend extends Statify {
 		}
 
 		// Skip tracking via User Agent.
-		$user_agent = filter_var(
-			( isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '' ),
-			FILTER_SANITIZE_STRING
-		);
+		$user_agent = sanitize_text_field( isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '' );
 		if ( is_null( $user_agent )
 			|| false === $user_agent
 			|| self::is_bot( $user_agent ) ) {


### PR DESCRIPTION
The string filter is deprecated as of PHP 8.1, so let's use another appropriate way to sanitize the input.