### PR TITLE
Replaced bot detection with JayBizzle/Crawler-Detect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,10 @@
     "statistics"
   ],
   "require": {
-    "php": "^5.2|^7|^8",
+    "php": "^5.3|^7|^8",
     "npm-asset/chartist": "^1.3.0",
-    "npm-asset/chartist-plugin-tooltips-updated": "^1.0.0"
+    "npm-asset/chartist-plugin-tooltips-updated": "^1.0.0",
+    "jaybizzle/crawler-detect": "^1.2"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -184,7 +184,7 @@ class Statify_Frontend extends Statify {
 		$user_agent = sanitize_text_field( isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '' );
 		if ( is_null( $user_agent )
 			|| false === $user_agent
-			|| self::is_bot( $user_agent ) ) {
+			|| self::is_bot() ) {
 			return true;
 		}
 
@@ -212,33 +212,13 @@ class Statify_Frontend extends Statify {
 	 *
 	 * @since 1.7.0
 	 *
-	 * @param  string $user_agent Server user agent string.
-	 *
-	 * @return boolean $is_bot     TRUE if user agent is a bot, FALSE if not.
+	 * @return boolean $is_bot     true if user agent is a bot, false if not.
 	 */
-	private static function is_bot( $user_agent ) {
-		$user_agent = strtolower( $user_agent );
+	private static function is_bot() {
+		$crawler_detect = new \Jaybizzle\CrawlerDetect\CrawlerDetect();
 
-		$identifiers = array(
-			'bot',
-			'slurp',
-			'crawler',
-			'spider',
-			'curl',
-			'facebook',
-			'fetch',
-			'python',
-			'wget',
-			'monitor',
-		);
-
-		foreach ( $identifiers as $identifier ) {
-			if ( strpos( $user_agent, $identifier ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
+		// Check the user agent of the current 'visitor' via the user agent and http_from header.
+		return $crawler_detect->isCrawler();
 	}
 
 	/**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -36,6 +36,6 @@
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="5.2-"/>
+    <config name="testVersion" value="5.3-"/>
     <rule ref="PHPCompatibilityWP"/>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
 * Tested up to:      6.1
-* Requires PHP:      5.2
+* Requires PHP:      5.3
 * Stable tag:        1.8.4
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html

--- a/statify.php
+++ b/statify.php
@@ -53,6 +53,8 @@ register_uninstall_hook(
 	)
 );
 
+/* Composer Autoload */
+require __DIR__ . '/vendor/autoload.php';
 
 /* Autoload */
 spl_autoload_register( 'statify_autoload' );


### PR DESCRIPTION
Implemented Composer Autoload for JayBizzle/Crawler-Detect and replaced bot detection in class-statify-frontend.php with CrawlerDetect function.

Solution for https://github.com/pluginkollektiv/statify/issues/217