### PR TITLE
integrate extended evaluation

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -63,7 +63,8 @@ body.rtl .statify-chart * {
 
 
 .statify-table th,
-.statify-table td:last-child {
+.statify-table tr.statify-table-sum td,
+.statify-table td.statify-table-sum {
 	font-weight: 700;
 }
 

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,6 +1,6 @@
 /* @group Front page */
 
-#statify_chart {
+.statify-chart {
 	color: #a7aaad;
 	flex: 0 0 100%;
 	height: 140px;
@@ -10,32 +10,38 @@
 	text-align: center;
 }
 
-#statify_chart * {
+.statify-chart * {
 	direction: ltr;
 }
 
-body.rtl #statify_chart * {
+body.rtl .statify-chart * {
 	direction: rtl;
 }
 
-#statify_chart .spinner {
+.statify-chart .spinner {
 	float: none;
 	margin: 1em;
 }
 
-#statify_chart .ct-line {
+.statify-chart .ct-line {
 	stroke: #3582c4;
 	stroke-width: 2px;
 }
 
-#statify_chart .ct-point {
+.statify-chart .ct-point {
 	fill: #fff;
 	stroke: #3582c4;
 	stroke-width: 1.5px;
 }
 
-#statify_chart .ct-area {
+.statify-chart .ct-area {
 	fill: #3582c4;
+}
+
+.statify-chart .ct-label.ct-horizontal.ct-end {
+	align-items: center;
+	justify-content: center;
+	margin-left: -50%;
 }
 
 .statify-chartist-tooltip {
@@ -54,6 +60,24 @@ body.rtl #statify_chart * {
 .statify-chartist-tooltip .chartist-tooltip-meta {
 	color: #3582c4;
 }
+
+
+.statify-table th,
+.statify-table td:last-child {
+	font-weight: 700;
+}
+
+.statify-table tr.placeholder {
+	background-color: #fff;
+}
+
+.statify-table tr.placeholder td span {
+	background-color: #f5f5f5;
+	border-radius: 1em;
+	display: inline-block;
+	width: 80%;
+}
+
 
 #statify_dashboard .postbox-title-action a,
 #statify_dashboard .settings-link a {
@@ -137,6 +161,23 @@ body.rtl #statify_chart * {
 	float: right;
 	margin: 0;
 	line-height: 28px;
+}
+
+.statify-chart-container {
+	background: #fff;
+	margin: 1em 0;
+	padding: 1em;
+}
+
+.statify-chart-container .statify-chart {
+	height: 280px;
+	margin: 10px 20px;
+}
+
+.statify-chart-title {
+	text-align: center;
+	font-size: 1.5em;
+	padding: 0.5em 0;
 }
 
 /* @end group */

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -79,6 +79,10 @@ body.rtl .statify-chart * {
 	width: 80%;
 }
 
+.statify-table + a.button {
+	margin: 1em 0 0 1em;
+}
+
 
 #statify_dashboard .postbox-title-action a,
 #statify_dashboard .settings-link a {

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -38,10 +38,18 @@ body.rtl .statify-chart * {
 	fill: #3582c4;
 }
 
+.statify-chart .ct-bar {
+	stroke: #3582c4;
+}
+
 .statify-chart .ct-label.ct-horizontal.ct-end {
 	align-items: center;
 	justify-content: center;
 	margin-left: -50%;
+}
+
+.statify-chart .ct-chart-bar .ct-label.ct-horizontal.ct-end {
+	margin-left: initial;
 }
 
 .statify-chartist-tooltip {
@@ -179,10 +187,20 @@ body.rtl .statify-chart * {
 	margin: 10px 20px;
 }
 
+.statify-chart-container .statify-legend {
+	column-gap: 2em;
+	column-width: 20em;
+	list-style-type: decimal;
+}
+
 .statify-chart-title {
 	text-align: center;
 	font-size: 1.5em;
 	padding: 0.5em 0;
+}
+
+#statify-dashboard-controls {
+	margin: 1em 0;
 }
 
 /* @end group */

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -22,10 +22,11 @@ class Statify_Api extends Statify {
 	 *
 	 * @var    string
 	 */
-	const REST_NAMESPACE   = 'statify/v1';
+	const REST_NAMESPACE = 'statify/v1';
 	const REST_ROUTE_TRACK = 'track';
 	const REST_ROUTE_STATS = 'stats';
 	const REST_ROUTE_RESET = 'reset';
+	const REST_ROUTE_STATS_EXTENDED = 'stats/extended';
 
 	/**
 	 * Initialize REST API routes.
@@ -65,6 +66,16 @@ class Statify_Api extends Statify {
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_STATS_EXTENDED,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_extended' ),
+				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
 			)
 		);
 
@@ -116,7 +127,7 @@ class Statify_Api extends Statify {
 			if ( null !== $referrer ) {
 				$referrer = filter_var( $referrer, FILTER_SANITIZE_URL );
 			}
-			$target   = $request->get_param( 'target' );
+			$target = $request->get_param( 'target' );
 			if ( null !== $target ) {
 				$target = filter_var( $target, FILTER_SANITIZE_URL );
 			}
@@ -137,7 +148,7 @@ class Statify_Api extends Statify {
 	public static function get_stats( WP_REST_Request $request ): WP_REST_Response {
 		$refresh = '1' === $request->get_param( 'refresh' );
 
-		$stats  = Statify_Dashboard::get_stats( $refresh );
+		$stats = Statify_Dashboard::get_stats( $refresh );
 
 		$visits          = $stats['visits'];
 		$stats['visits'] = array();
@@ -192,5 +203,54 @@ class Statify_Api extends Statify {
 			),
 			200
 		);
+	}
+
+	/**
+	 * Get extended statistics.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response.
+	 *
+	 * @since 2.0.0
+	 */
+	public static function get_extended( WP_REST_Request $request ): WP_REST_Response {
+		$scope = $request->get_param( 'scope' );
+		$post  = $request->get_param( 'post' );
+
+		$status = 200;
+		if ( 'year' === $scope ) {
+			$stats = Statify_Evaluation::get_views_for_all_years( $post );
+		} elseif ( 'month' === $scope ) {
+			$visits  = Statify_Evaluation::get_views_for_all_months( $post );
+			$stats   = array( 'visits' => array() );
+			$last_ym = 0;
+			foreach ( $visits as $ym => $v ) {
+				$ym         = explode( '-', $ym );
+				$year       = intval( $ym[0] );
+				$month      = intval( $ym[1] );
+				$year_month = $year * 12 + $month;
+				for ( $ym = $last_ym + 1; $last_ym > 0 && $ym < $year_month; $ym++ ) {
+					// Fill gaps.
+					$y = intval( $ym / 12 );
+					if ( ! isset( $stats['visits'][ $y ] ) ) {
+						$stats['visits'][ $y ] = array();
+					}
+					$stats['visits'][ $y ][ $ym % 12 ] = 0;
+				}
+				if ( ! isset( $stats['visits'][ $year ] ) ) {
+					$stats['visits'][ $year ] = array();
+				}
+				$stats['visits'][ $year ][ $month ] = $v;
+				$last_ym                            = $year_month;
+			}
+		} elseif ( 'day' === $scope ) {
+			$stats = Statify_Evaluation::get_views_for_all_days( $post );
+		} else {
+			$stats  = array( 'error' => 'invalid scope (allowed: year, month, day)' );
+			$status = 400;
+		}
+
+		return new WP_REST_Response( $stats, $status );
 	}
 }

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -215,42 +215,83 @@ class Statify_Api extends Statify {
 	 * @since 2.0.0
 	 */
 	public static function get_extended( WP_REST_Request $request ): WP_REST_Response {
+		// Verify scope.
 		$scope = $request->get_param( 'scope' );
-		$post  = $request->get_param( 'post' );
-
-		$status = 200;
-		if ( 'year' === $scope ) {
-			$stats = Statify_Evaluation::get_views_for_all_years( $post );
-		} elseif ( 'month' === $scope ) {
-			$visits  = Statify_Evaluation::get_views_for_all_months( $post );
-			$stats   = array( 'visits' => array() );
-			$last_ym = 0;
-			foreach ( $visits as $ym => $v ) {
-				$ym         = explode( '-', $ym );
-				$year       = intval( $ym[0] );
-				$month      = intval( $ym[1] );
-				$year_month = $year * 12 + $month;
-				for ( $ym = $last_ym + 1; $last_ym > 0 && $ym < $year_month; $ym++ ) {
-					// Fill gaps.
-					$y = intval( $ym / 12 );
-					if ( ! isset( $stats['visits'][ $y ] ) ) {
-						$stats['visits'][ $y ] = array();
-					}
-					$stats['visits'][ $y ][ $ym % 12 ] = 0;
-				}
-				if ( ! isset( $stats['visits'][ $year ] ) ) {
-					$stats['visits'][ $year ] = array();
-				}
-				$stats['visits'][ $year ][ $month ] = $v;
-				$last_ym                            = $year_month;
-			}
-		} elseif ( 'day' === $scope ) {
-			$stats = Statify_Evaluation::get_views_for_all_days( $post );
-		} else {
-			$stats  = array( 'error' => 'invalid scope (allowed: year, month, day)' );
-			$status = 400;
+		if ( ! in_array( $scope, array( 'year', 'month', 'day' ) ) ) {
+			return new WP_REST_Response(
+				array( 'error' => 'invalid scope (allowed: year, month, day)' ),
+				400
+			);
 		}
 
-		return new WP_REST_Response( $stats, $status );
+		// Retrieve from cache, if data is not post-specific.
+		$post  = $request->get_param( 'post' );
+		$stats = false;
+		if ( ! $post ) {
+			$stats = self::from_cache( $scope );
+		}
+
+		if ( ! $stats ) {
+			if ( 'year' === $scope ) {
+				$stats = Statify_Evaluation::get_views_for_all_years( $post );
+			} elseif ( 'month' === $scope ) {
+				$visits  = Statify_Evaluation::get_views_for_all_months( $post );
+				$stats   = array( 'visits' => array() );
+				$last_ym = 0;
+				foreach ( $visits as $ym => $v ) {
+					$ym         = explode( '-', $ym );
+					$year       = intval( $ym[0] );
+					$month      = intval( $ym[1] );
+					$year_month = $year * 12 + $month;
+					for ( $ym = $last_ym + 1; $last_ym > 0 && $ym < $year_month; $ym++ ) {
+						// Fill gaps.
+						$y = intval( $ym / 12 );
+						if ( ! isset( $stats['visits'][ $y ] ) ) {
+							$stats['visits'][ $y ] = array();
+						}
+						$stats['visits'][ $y ][ $ym % 12 ] = 0;
+					}
+					if ( ! isset( $stats['visits'][ $year ] ) ) {
+						$stats['visits'][ $year ] = array();
+					}
+					$stats['visits'][ $year ][ $month ] = $v;
+					$last_ym                            = $year_month;
+				}
+			} elseif ( 'day' === $scope ) {
+				$stats = Statify_Evaluation::get_views_for_all_days( $post );
+			}
+
+			// Update cache, if data is not post-specific.
+			if ( ! $post ) {
+				self::update_cache( $scope, $stats );
+			}
+		}
+
+		return new WP_REST_Response( $stats );
+	}
+
+	/**
+	 * Retrieve data from cache.
+	 *
+	 * @param string $scope Scope (year, month, day).
+	 *
+	 * @return array|false Transient data or FALSE.
+	 */
+	private static function from_cache( string $scope ) {
+		return get_transient( 'statify_data_' . $scope );
+	}
+
+	/**
+	 * Update data cache.
+	 *
+	 * @param string $scope Scope (year, month, day).
+	 * @param array  $data  Data.
+	 */
+	private static function update_cache( string $scope, array $data ): void {
+		set_transient(
+			'statify_data_' . $scope,
+			$data,
+			30 * MINUTE_IN_SECONDS
+		);
 	}
 }

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -28,6 +28,7 @@ class Statify_Api extends Statify {
 	const REST_ROUTE_RESET = 'reset';
 	const REST_ROUTE_STATS_EXTENDED = 'stats/extended';
 	const REST_ROUTE_STATS_POSTS = 'stats/posts';
+	const REST_ROUTE_STATS_REFERRERS = 'stats/referrers';
 	const REST_ROUTE_POSTS = 'posts';
 
 	/**
@@ -87,6 +88,16 @@ class Statify_Api extends Statify {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_stats_posts' ),
+				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_STATS_REFERRERS,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_stats_referrers' ),
 				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
 			)
 		);
@@ -319,7 +330,7 @@ class Statify_Api extends Statify {
 				function ( $url ) {
 					return array(
 						'url'   => $url,
-						'title' => self::post_title( $url ),
+						'title' => Statify_Evaluation::post_title( $url ),
 					);
 				},
 				Statify_Evaluation::get_post_urls()
@@ -349,6 +360,7 @@ class Statify_Api extends Statify {
 			return new WP_REST_Response( array( 'error' => 'invalid post type' ), 400 );
 		}
 
+		// Date filter.
 		$start = self::get_date( $request, 'start' );
 		$end   = self::get_date( $request, 'end' );
 		$cache = empty( $start ) && empty( $end );
@@ -371,7 +383,7 @@ class Statify_Api extends Statify {
 						return array(
 							'count'    => intval( $d['count'] ),
 							'url'      => $url,
-							'title'    => self::post_title( $url ),
+							'title'    => Statify_Evaluation::post_title( $url ),
 							'type'     => $type,
 							'typeName' => self::type_name( $type ),
 						);
@@ -412,6 +424,40 @@ class Statify_Api extends Statify {
 	}
 
 	/**
+	 * Get stats per referrers.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response.
+	 *
+	 * @since 2.0.0
+	 */
+	public static function get_stats_referrers( WP_REST_Request $request ): WP_REST_Response {
+		// Single post requested?
+		$post  = $request->get_param( 'post' );
+
+		// Date filter.
+		$start = self::get_date( $request, 'start' );
+		$end   = self::get_date( $request, 'end' );
+		$data = false;
+		if ( empty( $post ) && empty( $start ) && empty( $end ) ) {
+			// Retrieve data from cache.
+			$data = self::from_cache( 'referrers' );
+		}
+		if ( ! $data ) {
+			// Generate data for all types.
+			$data = Statify_Evaluation::get_views_for_all_referrers( $post, $start, $end );
+
+			if ( empty( $post ) && empty( $start ) && empty( $end ) ) {
+				// Store in cache.
+				self::update_cache( 'referrers', '', $data );
+			}
+		}
+
+		return new WP_REST_Response( $data );
+	}
+
+	/**
 	 * Retrieve data from cache.
 	 *
 	 * @param string $scope Scope (year, month, day).
@@ -436,28 +482,6 @@ class Statify_Api extends Statify {
 			$data,
 			30 * MINUTE_IN_SECONDS
 		);
-	}
-
-	/**
-	 * Get post title by URL.
-	 *
-	 * @param string $url Target URL.
-	 *
-	 * @return string Post title, fallback to URL of not available.
-	 */
-	private static function post_title( string $url ): string {
-		if ( '' === $url ) {
-			return __( 'all posts', 'statify' );
-		}
-		if ( '/' === $url ) {
-			return __( 'Home Page', 'statify' );
-		}
-		$post_id = url_to_postid( $url );
-		if ( 0 === $post_id ) {
-			return esc_url( $url );
-		}
-
-		return get_the_title( $post_id );
 	}
 
 	/**

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -224,11 +224,23 @@ class Statify_Api extends Statify {
 			);
 		}
 
+		// Parse year, if provided.
+		$yr = $request->get_param( 'year' ) ?? 0;
+		if ( ! empty( $yr ) ) {
+			$yr = intval( $yr );
+			if ( $yr <= 0 ) {
+				return new WP_REST_Response(
+					array( 'error' => 'invalid year' ),
+					400
+				);
+			}
+		}
+
 		// Retrieve from cache, if data is not post-specific.
 		$post  = $request->get_param( 'post' );
 		$stats = false;
 		if ( ! $post ) {
-			$stats = self::from_cache( $scope );
+			$stats = self::from_cache( $scope, $yr );
 		}
 
 		if ( ! $stats ) {
@@ -258,12 +270,12 @@ class Statify_Api extends Statify {
 					$last_ym                            = $year_month;
 				}
 			} elseif ( 'day' === $scope ) {
-				$stats = Statify_Evaluation::get_views_for_all_days( $post );
+				$stats = Statify_Evaluation::get_views_for_all_days( $yr, $post );
 			}
 
 			// Update cache, if data is not post-specific.
 			if ( ! $post ) {
-				self::update_cache( $scope, $stats );
+				self::update_cache( $scope, $yr, $stats );
 			}
 		}
 
@@ -274,22 +286,24 @@ class Statify_Api extends Statify {
 	 * Retrieve data from cache.
 	 *
 	 * @param string $scope Scope (year, month, day).
+	 * @param int    $index Optional index (e.g. year).
 	 *
 	 * @return array|false Transient data or FALSE.
 	 */
-	private static function from_cache( string $scope ) {
-		return get_transient( 'statify_data_' . $scope );
+	private static function from_cache( string $scope, int $index = 0 ) {
+		return get_transient( 'statify_data_' . $scope . ( $index > 0 ? '_' . $index : '' ) );
 	}
 
 	/**
 	 * Update data cache.
 	 *
 	 * @param string $scope Scope (year, month, day).
+	 * @param int    $index Optional index (e.g. year).
 	 * @param array  $data  Data.
 	 */
-	private static function update_cache( string $scope, array $data ): void {
+	private static function update_cache( string $scope, int $index, array $data ): void {
 		set_transient(
-			'statify_data_' . $scope,
+			'statify_data_' . $scope . ( $index > 0 ? '_' . $index : '' ),
 			$data,
 			30 * MINUTE_IN_SECONDS
 		);

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -27,6 +27,7 @@ class Statify_Api extends Statify {
 	const REST_ROUTE_STATS = 'stats';
 	const REST_ROUTE_RESET = 'reset';
 	const REST_ROUTE_STATS_EXTENDED = 'stats/extended';
+	const REST_ROUTE_POSTS = 'posts';
 
 	/**
 	 * Initialize REST API routes.
@@ -75,6 +76,16 @@ class Statify_Api extends Statify {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_extended' ),
+				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_POSTS,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_posts' ),
 				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
 			)
 		);
@@ -283,6 +294,33 @@ class Statify_Api extends Statify {
 	}
 
 	/**
+	 * Get post URLs.
+	 *
+	 * @return WP_REST_Response The response.
+	 *
+	 * @since 2.0.0
+	 */
+	public static function get_posts(): WP_REST_Response {
+		$posts = self::from_cache( 'posts' );
+
+		if ( ! $posts ) {
+			$posts = array_map(
+				function ( $url ) {
+					return array(
+						'url'   => $url,
+						'title' => self::post_title( $url ),
+					);
+				},
+				Statify_Evaluation::get_post_urls()
+			);
+
+			self::update_cache( 'posts', 0, $posts );
+		}
+
+		return new WP_REST_Response( $posts );
+	}
+
+	/**
 	 * Retrieve data from cache.
 	 *
 	 * @param string $scope Scope (year, month, day).
@@ -307,5 +345,27 @@ class Statify_Api extends Statify {
 			$data,
 			30 * MINUTE_IN_SECONDS
 		);
+	}
+
+	/**
+	 * Get post title by URL.
+	 *
+	 * @param string $url Target URL.
+	 *
+	 * @return string Post title, fallback to URL of not available.
+	 */
+	private static function post_title( string $url ): string {
+		if ( '' === $url ) {
+			return __( 'all posts', 'statify' );
+		}
+		if ( '/' === $url ) {
+			return __( 'Home Page', 'statify' );
+		}
+		$post_id = url_to_postid( $url );
+		if ( 0 === $post_id ) {
+			return esc_url( $url );
+		}
+
+		return get_the_title( $post_id );
 	}
 }

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -27,6 +27,7 @@ class Statify_Api extends Statify {
 	const REST_ROUTE_STATS = 'stats';
 	const REST_ROUTE_RESET = 'reset';
 	const REST_ROUTE_STATS_EXTENDED = 'stats/extended';
+	const REST_ROUTE_STATS_POSTS = 'stats/posts';
 	const REST_ROUTE_POSTS = 'posts';
 
 	/**
@@ -76,6 +77,16 @@ class Statify_Api extends Statify {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_extended' ),
+				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_STATS_POSTS,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_stats_posts' ),
 				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
 			)
 		);
@@ -301,7 +312,7 @@ class Statify_Api extends Statify {
 	 * @since 2.0.0
 	 */
 	public static function get_posts(): WP_REST_Response {
-		$posts = self::from_cache( 'posts' );
+		$posts = self::from_cache( 'post_urls' );
 
 		if ( ! $posts ) {
 			$posts = array_map(
@@ -314,34 +325,114 @@ class Statify_Api extends Statify {
 				Statify_Evaluation::get_post_urls()
 			);
 
-			self::update_cache( 'posts', 0, $posts );
+			self::update_cache( 'post_urls', 0, $posts );
 		}
 
 		return new WP_REST_Response( $posts );
 	}
 
 	/**
+	 * Get stats per post.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response.
+	 *
+	 * @since 2.0.0
+	 */
+	public static function get_stats_posts( WP_REST_Request $request ): WP_REST_Response {
+		// Post type requested?
+		$type = $request->get_param( 'type' );
+		if ( empty( $type ) || 'popular' === $type ) {
+			$type = '';
+		} elseif ( ! in_array( $type, Statify_Evaluation::get_post_types(), true ) ) {
+			return new WP_REST_Response( array( 'error' => 'invalid post type' ), 400 );
+		}
+
+		$start = self::get_date( $request, 'start' );
+		$end   = self::get_date( $request, 'end' );
+		$cache = empty( $start ) && empty( $end );
+		$data  = false;
+
+		if ( $cache ) {
+			// Retrieve typed data from cache.
+			$data = self::from_cache( 'posts', $type );
+		}
+		if ( ! $data ) {
+			// Retrieve data from cache for all types or generate it.
+			if ( $cache ) {
+				$data = self::from_cache( 'posts' );
+			}
+			if ( ! $data ) {
+				$data = array_map(
+					function ( $d ) {
+						$url  = $d['url'];
+						$type = self::post_type( $url );
+						return array(
+							'count'    => intval( $d['count'] ),
+							'url'      => $url,
+							'title'    => self::post_title( $url ),
+							'type'     => $type,
+							'typeName' => self::type_name( $type ),
+						);
+					},
+					Statify_Evaluation::get_views_of_most_popular_posts( $start, $end )
+				);
+
+				if ( $cache ) {
+					// Cache complete data.
+					self::update_cache( 'posts', '', $data );
+				}
+			}
+
+			if ( $cache ) {
+				// Cache complete data.
+				self::update_cache( 'posts', '', $data );
+			}
+
+			// Filter by type.
+			if ( ! empty( $type ) ) {
+				$data = array_values(
+					array_filter(
+						$data,
+						function ( $d ) use ( $type ) {
+							return $d['type'] === $type;
+						}
+					)
+				);
+
+				if ( $cache ) {
+					// Cache typed data.
+					self::update_cache( 'posts', $type, $data );
+				}
+			}
+		}
+
+		return new WP_REST_Response( $data );
+	}
+
+	/**
 	 * Retrieve data from cache.
 	 *
 	 * @param string $scope Scope (year, month, day).
-	 * @param int    $index Optional index (e.g. year).
+	 * @param string $index Optional index (e.g. year).
 	 *
 	 * @return array|false Transient data or FALSE.
 	 */
-	private static function from_cache( string $scope, int $index = 0 ) {
-		return get_transient( 'statify_data_' . $scope . ( $index > 0 ? '_' . $index : '' ) );
+	private static function from_cache( string $scope, string $index = '' ) {
+		return get_transient( 'statify_data_' . $scope . ( ! empty( $index ) ? '_' . $index : '' ) );
 	}
 
 	/**
 	 * Update data cache.
 	 *
 	 * @param string $scope Scope (year, month, day).
-	 * @param int    $index Optional index (e.g. year).
+	 * @param string $index Optional index (e.g. year).
 	 * @param array  $data  Data.
 	 */
-	private static function update_cache( string $scope, int $index, array $data ): void {
+	private static function update_cache( string $scope, string $index, array $data ): void {
 		set_transient(
-			'statify_data_' . $scope . ( $index > 0 ? '_' . $index : '' ),
+			'statify_data_' . $scope . ( ! empty( $index ) ? '_' . $index : '' ),
 			$data,
 			30 * MINUTE_IN_SECONDS
 		);
@@ -367,5 +458,50 @@ class Statify_Api extends Statify {
 		}
 
 		return get_the_title( $post_id );
+	}
+
+	/**
+	 * Get post type by URL.
+	 *
+	 * @param string $url URL.
+	 *
+	 * @return string Post type, empty string if not available.
+	 */
+	private static function post_type( string $url ): string {
+		$post_id = url_to_postid( $url );
+		if ( 0 === $post_id ) {
+			return '';
+		}
+		return get_post_type( $post_id );
+	}
+
+	/**
+	 * Get name of a given post type (e.g. "Post" for "post")
+	 *
+	 * @param string $type Post type.
+	 *
+	 * @return string Type name.
+	 */
+	private static function type_name( string $type ): string {
+		if ( empty( $type ) ) {
+			return '';
+		}
+		return get_post_type_object( $type )->labels->singular_name;
+	}
+
+	/**
+	 * Get ISO date parameter from request.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @param string          $param   Parameter name.
+	 *
+	 * @return string ISO date string or empty, if missing/invalid.
+	 */
+	private static function get_date( WP_REST_Request $request, string $param ): string {
+		$val = $request->get_param( $param );
+		if ( empty( $val ) || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $val ) ) {
+			return '';
+		}
+		return $val;
 	}
 }

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -19,14 +19,6 @@ defined( 'ABSPATH' ) || exit;
 class Statify_Dashboard extends Statify {
 
 	/**
-	 * Plugin version.
-	 *
-	 * @since  1.4.0
-	 * @var    string
-	 */
-	protected static $_plugin_version;
-
-	/**
 	 * Dashboard widget initialize
 	 *
 	 * @since   0.1.0
@@ -45,9 +37,6 @@ class Statify_Dashboard extends Statify {
 			wp_normalize_path( sprintf( '%s/lang', STATIFY_DIR ) )
 		);
 
-		// Plugin version.
-		self::_get_version();
-
 		// Add dashboard widget.
 		wp_add_dashboard_widget(
 			'statify_dashboard',
@@ -57,81 +46,11 @@ class Statify_Dashboard extends Statify {
 		);
 
 		// Init CSS.
-		add_action( 'admin_print_styles', array( __CLASS__, 'add_style' ) );
+		add_action( 'admin_print_styles', array( 'Statify', 'add_style' ) );
 
 		// Init JS.
-		add_action( 'admin_print_scripts', array( __CLASS__, 'add_js' ) );
+		add_action( 'admin_print_scripts', array( 'Statify', 'add_js' ) );
 	}
-
-	/**
-	 * Print CSS
-	 *
-	 * @since   0.1.0
-	 * @version 1.4.0
-	 */
-	public static function add_style(): void {
-
-		// Register CSS.
-		wp_register_style(
-			'chartist_css',
-			plugins_url( '/css/chartist.min.css', STATIFY_FILE ),
-			array(),
-			self::$_plugin_version
-		);
-		wp_register_style(
-			'chartist_tooltip_css',
-			plugins_url( '/css/chartist-plugin-tooltip.min.css', STATIFY_FILE ),
-			array(),
-			self::$_plugin_version
-		);
-		wp_register_style(
-			'statify',
-			plugins_url( '/css/dashboard.min.css', STATIFY_FILE ),
-			array(),
-			self::$_plugin_version
-		);
-
-		// Load CSS.
-		wp_enqueue_style( 'chartist_css' );
-		wp_enqueue_style( 'chartist_tooltip_css' );
-		wp_enqueue_style( 'statify' );
-	}
-
-	/**
-	 * Print JavaScript
-	 *
-	 * @since    0.1.0
-	 * @version  1.4.0
-	 */
-	public static function add_js(): void {
-
-		// Register JS.
-		wp_register_script(
-			'chartist_js',
-			plugins_url( 'js/chartist.min.js', STATIFY_FILE ),
-			array(),
-			self::$_plugin_version,
-			true
-		);
-		wp_register_script(
-			'chartist_tooltip_js',
-			plugins_url( 'js/chartist-plugin-tooltip.min.js', STATIFY_FILE ),
-			array( 'chartist_js' ),
-			self::$_plugin_version,
-			true
-		);
-		wp_register_script(
-			'statify_chart_js',
-			plugins_url( 'js/dashboard.min.js', STATIFY_FILE ),
-			array( 'wp-api-fetch', 'chartist_tooltip_js', 'wp-i18n' ),
-			self::$_plugin_version,
-			true
-		);
-
-		// Sets translated strings for the script.
-		wp_set_script_translations( 'statify_chart_js', 'statify' );
-	}
-
 
 	/**
 	 * Print widget frontview.
@@ -224,22 +143,6 @@ class Statify_Dashboard extends Statify {
 		// Update values.
 		update_option( 'statify', $options );
 	}
-
-
-	/**
-	 * Set plugin version from plugin meta data
-	 *
-	 * @since    1.4.0
-	 * @version  1.4.0
-	 */
-	private static function _get_version(): void {
-
-		// Get plugin meta.
-		$meta = get_plugin_data( STATIFY_FILE );
-
-		self::$_plugin_version = $meta['Version'];
-	}
-
 
 	/**
 	 * Get stats from cache

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Statify: Statify_Evaluation class
+ *
+ * Extended evaluation methods for Statify.
+ * The logic was initially imported from "Statify – Extended Evaluation" by Patrick Robrecht.
+ *
+ * @package Statify
+ * @since   2.0.0
+ */
+
+// Quit if accessed outside WP context.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Statify Extended Evaluation.
+ *
+ * @since 2.0.0
+ */
+class Statify_Evaluation extends Statify {
+
+	/**
+	 * Returns the years Statify has collected data for in descending order.
+	 *
+	 * @return int[] an array of integers (e.g. 2016, 2015)
+	 */
+	public static function get_years(): array {
+		global $wpdb;
+
+		$results = $wpdb->get_results(
+			'SELECT DISTINCT YEAR(`created`) as `year`' .
+			" FROM `$wpdb->statify` " .
+			' ORDER BY `year` DESC',
+			ARRAY_A
+		);
+		$years = array();
+		foreach ( $results as $result ) {
+			$years[] = (int) $result['year'];
+		}
+
+		return $years;
+	}
+
+	/**
+	 * Returns the views for all days.
+	 * If the given URL is not the empty string, the result is restricted to the given post.
+	 *
+	 * @param string|null $post_url the URL of the post to select for (or the empty string for all posts).
+	 *
+	 * @return array an array with date as key and views as value
+	 */
+	public static function get_views_for_all_days( ?string $post_url = '' ): array {
+		global $wpdb;
+
+		if ( empty( $post_url ) ) {
+			// For all posts.
+			$results = $wpdb->get_results(
+				'SELECT `created` as `date`, COUNT(`created`) as `count`' .
+				" FROM `$wpdb->statify`" .
+				' GROUP BY `created`' .
+				' ORDER BY `created`',
+				ARRAY_A
+			);
+		} else {
+			// Only for selected posts.
+			$results = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT `created` as `date`, COUNT(`created`) as `count`' .
+					" FROM `$wpdb->statify`" .
+					' WHERE `target` = %s' .
+					' GROUP BY `created`' .
+					' ORDER BY `created`',
+					$post_url
+				),
+				ARRAY_A
+			);
+		}
+		$views_for_all_days = array();
+		foreach ( $results as $result ) {
+			$views_for_all_days[ $result['date'] ] = intval( $result['count'] );
+		}
+
+		return $views_for_all_days;
+	}
+
+	/**
+	 * Returns the views for all months.
+	 * If the given URL is not the empty string, the result is restricted to the given post.
+	 *
+	 * @param string|null $post_url the URL of the post to select for (or the empty string for all posts).
+	 *
+	 * @return array an array with month as key and views as value.
+	 */
+	public static function get_views_for_all_months( ?string $post_url = '' ): array {
+		global $wpdb;
+
+		if ( empty( $post_url ) ) {
+			// For all posts.
+			$results = $wpdb->get_results(
+				"SELECT DATE_FORMAT(`created`, '%Y-%m') as `date`, COUNT(`created`) as `count`" .
+				" FROM `$wpdb->statify`" .
+				' GROUP BY `date`' .
+				' ORDER BY `date`',
+				ARRAY_A
+			);
+		} else {
+			// Only for selected posts.
+			$results = $wpdb->get_results(
+				$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnsupportedPlaceholder
+					"SELECT DATE_FORMAT(`created`, '%Y-%m') as `date`, COUNT(`created`) as `count`
+                FROM `$wpdb->statify`
+                WHERE `target` = %s
+                GROUP BY `date`
+                ORDER BY `date`",
+					$post_url
+				),
+				ARRAY_A
+			);
+		}
+		$views_for_all_months = array();
+		foreach ( $results as $result ) {
+			$views_for_all_months[ $result['date'] ] = intval( $result['count'] );
+		}
+
+		return $views_for_all_months;
+	}
+
+	/**
+	 * Returns the views for all years.
+	 *
+	 * If the given URL is not the empty string, the result is restricted to the given post.
+	 *
+	 * @param string|null $post_url the URL of the post to select for (or the empty string for all posts).
+	 *
+	 * @return array an array with the year as key and views as value.
+	 */
+	public static function get_views_for_all_years( ?string $post_url = '' ): array {
+		global $wpdb;
+
+		if ( empty( $post_url ) ) {
+			// For all posts.
+			$results = $wpdb->get_results(
+				'SELECT YEAR(`created`) as `date`, COUNT(`created`) as `count`' .
+				" FROM `$wpdb->statify`" .
+				' GROUP BY `date`',
+				ARRAY_A
+			);
+		} else {
+			// Only for selected posts.
+			$results = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT YEAR(`created`) as `date`, COUNT(`created`) as `count`' .
+					" FROM `$wpdb->statify`" .
+					' WHERE `target` = %s' .
+					' GROUP BY `date`',
+					$post_url
+				),
+				ARRAY_A
+			);
+		}
+		$views_for_all_years = array();
+		foreach ( $results as $result ) {
+			$views_for_all_years[ $result['date'] ] = intval( $result['count'] );
+		}
+
+		return $views_for_all_years;
+	}
+
+	/**
+	 * Returns the most popular posts with their views count (in the date period if set).
+	 *
+	 * @param string $start the start date of the period.
+	 * @param string $end the end date of the period.
+	 *
+	 * @return array an array with the most popular posts, ordered by view count.
+	 */
+	public static function get_views_of_most_popular_posts( string $start = '', string $end = '' ): array {
+		global $wpdb;
+
+		if ( empty( $start ) && empty( $end ) ) {
+			$results = $wpdb->get_results(
+				'SELECT COUNT(`target`) as `count`, `target` as `url`' .
+				" FROM `$wpdb->statify`" .
+				' WHERE `target` IS NOT NULL' .
+				' GROUP BY `target`' .
+				' ORDER BY `count` DESC',
+				ARRAY_A
+			);
+		} else {
+			$results = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT COUNT(`target`) as `count`, `target` as `url`' .
+					" FROM `$wpdb->statify`" .
+					' WHERE `created` >= %s AND `created` <= %s' .
+					' GROUP BY `target`' .
+					' ORDER BY `count` DESC',
+					$start,
+					$end
+				),
+				ARRAY_A
+			);
+		}
+
+		foreach ( $results as &$result ) {
+			$result['count'] = intval( $result['count'] );
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Returns the most popular referrers with their views count.
+	 * If the given URL is not the empty string, the result is restricted to the given post.
+	 *
+	 * @param string|null $post_url the URL of the post to select for (or the empty string for all posts).
+	 * @param string|null $start the start date of the period.
+	 * @param string|null $end the end date of the period.
+	 *
+	 * @return array an array with the most referrers, ordered by view count
+	 */
+	public static function get_views_for_all_referrers( ?string $post_url = '', ?string $start = '', ?string $end = '' ): array {
+		global $wpdb;
+
+		if ( empty( $post_url ) ) {
+			// For all posts.
+			if ( empty( $start ) && empty( $end ) ) {
+				$where = "`referrer` != ''";
+				$param = array();
+			} else {
+				$where = "`referrer` != '' AND `created` >= %s AND `created` <= %s";
+				$param = array( $start, $end );
+			}
+		} elseif ( empty( $start ) && empty( $end ) ) {
+			// Only for selected posts.
+			$where = "`referrer` != '' AND target = %s";
+			$param = array( $post_url );
+		} else {
+			$where = "`referrer` != '' AND `target` = %s AND `created` >= %s AND `created` <= %s";
+			$param = array( $post_url, $start, $end );
+		}
+
+		$stmt = 'SELECT COUNT(`referrer`) as `count`, `referrer` as `url`,' .
+			" SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host`" .
+			" FROM `$wpdb->statify`" .
+			' WHERE ' . $where .
+			' GROUP BY `host`' .
+			' ORDER BY `count` DESC';
+
+		if ( ! empty( $param ) ) {
+			$stmt = $wpdb->prepare( $stmt, $param );
+		}
+		$results = $wpdb->get_results( $stmt, ARRAY_A );
+
+		foreach ( $results as &$result ) {
+			$result['count'] = intval( $result['count'] );
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Returns a list of all target URLs.
+	 *
+	 * @return string[] an array of urls
+	 */
+	public static function get_post_urls(): array {
+		global $wpdb;
+
+		return $wpdb->get_col(
+			'SELECT DISTINCT `target`' .
+			" FROM `$wpdb->statify`" .
+			' WHERE `target` IS NOT NULL' .
+			' ORDER BY `target` ASC'
+		);
+	}
+}

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -62,6 +62,15 @@ class Statify_Evaluation extends Statify {
 			'statify_content',
 			array( __CLASS__, 'show_content' )
 		);
+
+		add_submenu_page(
+			'statify_dashboard',
+			__( 'Referrers', 'statify' ) . ' &mdash; ' . __( 'Statify', 'statify' ),
+			__( 'Referrers', 'statify' ),
+			'see_statify_evaluation',
+			'statify_referrers',
+			array( __CLASS__, 'show_referrers' )
+		);
 	}
 
 	/**
@@ -76,6 +85,13 @@ class Statify_Evaluation extends Statify {
 	 */
 	public static function show_content(): void {
 		self::show_view( 'content' );
+	}
+
+	/**
+	 * Show the referrers page.
+	 */
+	public static function show_referrers(): void {
+		self::show_view( 'referrers' );
 	}
 
 	/**
@@ -391,5 +407,29 @@ class Statify_Evaluation extends Statify {
 		);
 
 		return array_merge( array( 'post', 'page' ), get_post_types( $types_args ) );
+	}
+
+	/**
+	 * Get post title by URL.
+	 *
+	 * @param string|null $url Target URL.
+	 *
+	 * @return string Post title, fallback to URL of not available.
+	 */
+	public static function post_title( ?string $url ): string {
+		if ( empty( $url ) ) {
+			$title = __( 'all posts', 'statify' );
+		} elseif ( '/' === $url ) {
+			$title = __( 'Home Page', 'statify' );
+		} else {
+			$post_id = url_to_postid( $url );
+			if ( 0 === $post_id ) {
+				$title = esc_url( $url );
+			} else {
+				$title = get_the_title( $post_id );
+			}
+		}
+
+		return $title;
 	}
 }

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -93,36 +93,35 @@ class Statify_Evaluation extends Statify {
 	 * Returns the views for all days.
 	 * If the given URL is not the empty string, the result is restricted to the given post.
 	 *
-	 * @param string|null $post_url the URL of the post to select for (or the empty string for all posts).
+	 * @param int         $single_year single year.
+	 * @param string|null $post_url    the URL of the post to select for (or the empty string for all posts).
 	 *
 	 * @return array an array with date as key and views as value
 	 */
-	public static function get_views_for_all_days( ?string $post_url = '' ): array {
+	public static function get_views_for_all_days( int $single_year = 0, ?string $post_url = '' ): array {
 		global $wpdb;
 
-		if ( empty( $post_url ) ) {
-			// For all posts.
-			$results = $wpdb->get_results(
-				'SELECT `created` as `date`, COUNT(`created`) as `count`' .
-				" FROM `$wpdb->statify`" .
-				' GROUP BY `created`' .
-				' ORDER BY `created`',
-				ARRAY_A
-			);
-		} else {
-			// Only for selected posts.
-			$results = $wpdb->get_results(
-				$wpdb->prepare(
-					'SELECT `created` as `date`, COUNT(`created`) as `count`' .
-					" FROM `$wpdb->statify`" .
-					' WHERE `target` = %s' .
-					' GROUP BY `created`' .
-					' ORDER BY `created`',
-					$post_url
-				),
-				ARRAY_A
-			);
+		$query = "SELECT `created` as `date`, COUNT(`created`) as `count` FROM `$wpdb->statify`";
+		$args = array();
+
+		if ( $single_year > 0 ) {
+			$query .= ' WHERE YEAR(`created`) = %d';
+			$args[] = $single_year;
 		}
+
+		if ( ! empty( $post_url ) ) {
+			$query .= ( $single_year > 0 ? ' AND' : ' WHERE' ) . ' `target` = %s';
+			$args[] = $post_url;
+		}
+
+		$query .= ' GROUP BY `created` ORDER BY `created`';
+
+		if ( ! empty( $args ) ) {
+			$query = $wpdb->prepare( $query, $args );
+		}
+
+		$results = $wpdb->get_results( $query, ARRAY_A );
+
 		$views_for_all_days = array();
 		foreach ( $results as $result ) {
 			$views_for_all_days[ $result['date'] ] = intval( $result['count'] );

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -53,18 +53,43 @@ class Statify_Evaluation extends Statify {
 			'dashicons-chart-area',
 			50
 		);
+
+		add_submenu_page(
+			'statify_dashboard',
+			__( 'Content', 'statify' ) . ' &mdash; ' . __( 'Statify', 'statify' ),
+			__( 'Content', 'statify' ),
+			'see_statify_evaluation',
+			'statify_content',
+			array( __CLASS__, 'show_content' )
+		);
 	}
 
 	/**
 	 * Show the dashboard page.
 	 */
 	public static function show_dashboard(): void {
+		self::show_view( 'dashboard' );
+	}
+
+	/**
+	 * Show the content page.
+	 */
+	public static function show_content(): void {
+		self::show_view( 'content' );
+	}
+
+	/**
+	 * Load a specific page view.
+	 *
+	 * @param string $view The view to load.
+	 */
+	private static function show_view( string $view ): void {
 		self::add_js();
 		self::add_style();
 		wp_enqueue_script( 'chartist_js' );
 		wp_enqueue_script( 'statify_chart_js' );
 
-		load_template( wp_normalize_path( STATIFY_DIR . '/views/view-dashboard.php' ) );
+		load_template( wp_normalize_path( STATIFY_DIR . '/views/view-' . $view . '.php' ) );
 	}
 
 	/**
@@ -257,7 +282,7 @@ class Statify_Evaluation extends Statify {
 	public static function get_views_of_most_popular_posts( string $start = '', string $end = '' ): array {
 		global $wpdb;
 
-		if ( empty( $start ) && empty( $end ) ) {
+		if ( empty( $start ) || empty( $end ) ) {
 			$results = $wpdb->get_results(
 				'SELECT COUNT(`target`) as `count`, `target` as `url`' .
 				" FROM `$wpdb->statify`" .
@@ -271,7 +296,7 @@ class Statify_Evaluation extends Statify {
 				$wpdb->prepare(
 					'SELECT COUNT(`target`) as `count`, `target` as `url`' .
 					" FROM `$wpdb->statify`" .
-					' WHERE `created` >= %s AND `created` <= %s' .
+					' WHERE `created` BETWEEN %s AND %s' .
 					' GROUP BY `target`' .
 					' ORDER BY `count` DESC',
 					$start,

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -127,6 +127,22 @@ class Statify_Evaluation extends Statify {
 			$views_for_all_days[ $result['date'] ] = intval( $result['count'] );
 		}
 
+		// Fill gaps with zeros.
+		if ( count( $views_for_all_days ) > 1 ) {
+			$period = new DatePeriod(
+				new DateTime( array_keys( $views_for_all_days )[0] ),
+				DateInterval::createFromDateString( '1 day' ),
+				new DateTime( array_keys( $views_for_all_days )[ count( $views_for_all_days ) - 1 ] )
+			);
+			foreach ( $period as $date ) {
+				$date = $date->format( 'Y-m-d' );
+				if ( ! array_key_exists( $date, $views_for_all_days ) ) {
+					$views_for_all_days[ $date ] = 0;
+				}
+			}
+			ksort( $views_for_all_days );
+		}
+
 		return $views_for_all_days;
 	}
 
@@ -168,6 +184,22 @@ class Statify_Evaluation extends Statify {
 		$views_for_all_months = array();
 		foreach ( $results as $result ) {
 			$views_for_all_months[ $result['date'] ] = intval( $result['count'] );
+		}
+
+		// Fill gaps with zeros.
+		if ( count( $views_for_all_months ) > 1 ) {
+			$period = new DatePeriod(
+				new DateTime( array_keys( $views_for_all_months )[0] ),
+				DateInterval::createFromDateString( '1 month' ),
+				new DateTime( array_keys( $views_for_all_months )[ count( $views_for_all_months ) - 1 ] )
+			);
+			foreach ( $period as $date ) {
+				$date = $date->format( 'Y-m' );
+				if ( ! array_key_exists( $date, $views_for_all_months ) ) {
+					$views_for_all_months[ $date ] = 0;
+				}
+			}
+			ksort( $views_for_all_months );
 		}
 
 		return $views_for_all_months;

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -18,6 +18,54 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.0.0
  */
 class Statify_Evaluation extends Statify {
+	const CAPABILITY_SEE_STATS = 'see_statify_evaluation';
+
+	/**
+	 * Add capability to see evaluations.
+	 */
+	public static function add_capability(): void {
+		if ( isset( self::$_options['show_widget_roles'] ) ) {
+			foreach ( self::$_options['show_widget_roles'] as $role_name ) {
+				$role = get_role( $role_name );
+				if ( $role ) {
+					$role->add_cap( self::CAPABILITY_SEE_STATS );
+				}
+			}
+		} else {
+			// Backwards compatibility for older statify versions without this option.
+			$role = get_role( 'administrator' );
+			if ( $role ) {
+				$role->add_cap( self::CAPABILITY_SEE_STATS );
+			}
+		}
+	}
+
+	/**
+	 * Create an item and submenu items in the WordPress admin menu.
+	 */
+	public static function add_menu(): void {
+		add_menu_page(
+			__( 'Statify', 'statify' ),
+			'Statify',
+			'see_statify_evaluation',
+			'statify_dashboard',
+			array( __CLASS__, 'show_dashboard' ),
+			'dashicons-chart-area',
+			50
+		);
+	}
+
+	/**
+	 * Show the dashboard page.
+	 */
+	public static function show_dashboard(): void {
+		self::add_js();
+		self::add_style();
+		wp_enqueue_script( 'chartist_js' );
+		wp_enqueue_script( 'statify_chart_js' );
+
+		load_template( wp_normalize_path( STATIFY_DIR . '/views/view-dashboard.php' ) );
+	}
 
 	/**
 	 * Returns the years Statify has collected data for in descending order.
@@ -273,5 +321,19 @@ class Statify_Evaluation extends Statify {
 			' WHERE `target` IS NOT NULL' .
 			' ORDER BY `target` ASC'
 		);
+	}
+
+	/**
+	 * Returns the post types of the site: post, page and custom post types.
+	 *
+	 * @return string[] an array of post type slugs.
+	 */
+	public static function get_post_types(): array {
+		$types_args = array(
+			'public' => true,
+			'_builtin' => false,
+		);
+
+		return array_merge( array( 'post', 'page' ), get_post_types( $types_args ) );
 	}
 }

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -34,6 +34,13 @@ class Statify {
 	public static $_options;
 
 	/**
+	 * Plugin version.
+	 *
+	 * @var string|null $plugin_version
+	 */
+	private static $plugin_version;
+
+	/**
 	 * Plugin initialization.
 	 *
 	 * @since    1.7 Replaces previously used instance() and __construct().
@@ -76,6 +83,8 @@ class Statify {
 			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify_Backend', 'add_action_link' ) );
 			add_action( 'admin_init', array( 'Statify_Settings', 'register_settings' ) );
 			add_action( 'admin_menu', array( 'Statify_Settings', 'add_admin_menu' ) );
+			add_action( 'admin_init', array( 'Statify_Evaluation', 'add_capability' ) );
+			add_action( 'admin_menu', array( 'Statify_Evaluation', 'add_menu' ) );
 			add_action( 'update_option_statify', array( 'Statify_Settings', 'action_update_options' ), 10, 2 );
 		} else {    // Frontend.
 			add_action( 'template_redirect', array( 'Statify_Frontend', 'track_visit' ) );
@@ -224,6 +233,100 @@ class Statify {
 
 		// Filter user_can_see_stats.
 		return apply_filters( 'statify__user_can_see_stats', $can_see );
+	}
+
+	/**
+	 * Print JavaScript.
+	 *
+	 * @since 2.0.0 Moved to Statify class
+	 */
+	public static function add_js(): void {
+		// Register JS.
+		wp_register_script(
+			'chartist_js',
+			plugins_url( 'js/chartist.min.js', STATIFY_FILE ),
+			array(),
+			self::get_version(),
+			true
+		);
+		wp_register_script(
+			'chartist_tooltip_js',
+			plugins_url( 'js/chartist-plugin-tooltip.min.js', STATIFY_FILE ),
+			array( 'chartist_js' ),
+			self::get_version(),
+			true
+		);
+		wp_register_script(
+			'statify_chart_js',
+			plugins_url( 'js/dashboard.min.js', STATIFY_FILE ),
+			array( 'wp-api-fetch', 'chartist_tooltip_js' ),
+			self::get_version(),
+			true
+		);
+
+		// Localize strings.
+		wp_localize_script(
+			'statify_chart_js',
+			'statifyDashboard',
+			array(
+				'i18n'  => array(
+					'months' => array_map(
+						function ( $m ) {
+							return date_i18n( 'M', strtotime( '0000-' . $m . '-01' ) );
+						},
+						range( 1, 12 )
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Print CSS
+	 *
+	 * @since 0.1.0
+	 * @since 2.0.0 Moved to Statify class
+	 */
+	public static function add_style(): void {
+		// Register CSS.
+		wp_register_style(
+			'chartist_css',
+			plugins_url( '/css/chartist.min.css', STATIFY_FILE ),
+			array(),
+			self::get_version()
+		);
+		wp_register_style(
+			'chartist_tooltip_css',
+			plugins_url( '/css/chartist-plugin-tooltip.min.css', STATIFY_FILE ),
+			array(),
+			self::get_version()
+		);
+		wp_register_style(
+			'statify',
+			plugins_url( '/css/dashboard.min.css', STATIFY_FILE ),
+			array(),
+			self::get_version()
+		);
+
+		// Load CSS.
+		wp_enqueue_style( 'chartist_css' );
+		wp_enqueue_style( 'chartist_tooltip_css' );
+		wp_enqueue_style( 'statify' );
+	}
+
+	/**
+	 * Set plugin version from plugin meta data
+	 *
+	 * @since 1.4.0
+	 * @since 2.0.0 Moved up to Statify class.
+	 */
+	protected static function get_version(): string {
+		if ( ! isset( self::$plugin_version ) ) {
+			$meta = get_plugin_data( STATIFY_FILE );
+			self::$plugin_version = $meta['Version'];
+		}
+
+		return self::$plugin_version;
 	}
 
 	/**

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -270,7 +270,8 @@ class Statify {
 			'statifyDashboard',
 			array(
 				'i18n'  => array(
-					'months' => array_map(
+					'sitename' => sanitize_key( get_bloginfo( 'name' ) ),
+					'months'   => array_map(
 						function ( $m ) {
 							return date_i18n( 'M', strtotime( '0000-' . $m . '-01' ) );
 						},

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -12,6 +12,10 @@
 	);
 	const refreshBtn = document.getElementById('statify_refresh');
 
+	const chartElemMonthly = document.getElementById('statify_chart_monthly');
+	const chartElemYearly = document.getElementById('statify_chart_yearly');
+	const yearlyTable = document.getElementById('statify-table-yearly');
+
 	/**
 	 * Update the dashboard widget
 	 *
@@ -31,7 +35,7 @@
 				const labels = Object.keys(data.visits);
 				const values = Object.values(data.visits);
 
-				render(chartElem, labels, values);
+				render(chartElem, labels, values, false);
 
 				// Render top lists.
 				if (referrerTable) {
@@ -60,13 +64,62 @@
 	}
 
 	/**
+	 * Render monthly statistics.
+	 *
+	 * @return {Promise<{visits: {[key: string]: {[key: string]: number}}}>} Data promise from API.
+	 */
+	function loadMonthly() {
+		// Load data from API.
+		return wp.apiFetch({ path: '/statify/v1/stats/extended?scope=month' });
+	}
+
+	/**
+	 * Render monthly statistics.
+	 *
+	 * @param {HTMLElement}                                        root Root element.
+	 * @param {{visits: {[key: string]: {[key: string]: number}}}} data Data from API.
+	 */
+	function renderMonthly(root, data) {
+		const labels = Object.keys(data.visits).flatMap((y) =>
+			Object.keys(data.visits[y]).map(
+				(m) => statifyDashboard.i18n.months[m - 1] + ' ' + y
+			)
+		);
+		const values = Object.values(data.visits).flatMap((y) =>
+			Object.values(y)
+		);
+
+		render(root, labels, values);
+	}
+
+	/**
+	 * Render yearly statistics.
+	 *
+	 * @param {HTMLElement}                                        root Root element.
+	 * @param {{visits: {[key: string]: {[key: string]: number}}}} data Data from API.
+	 */
+	function renderYearly(root, data) {
+		const labels = Object.keys(data.visits);
+		const values = Object.values(data.visits).flatMap((y) =>
+			Object.values(y).reduce((a, b) => a + b, 0)
+		);
+
+		render(root, labels, values);
+	}
+
+	/**
 	 * Render statistics chart.
 	 *
-	 * @param {HTMLElement} root   Root element.
-	 * @param {string[]}    labels Labels.
-	 * @param {number[]}    values Values.
+	 * @param {HTMLElement} root     Root element.
+	 * @param {string[]}    labels   Labels.
+	 * @param {number[]}    values   Values.
+	 * @param {boolean}     showAxis Show X axis?
 	 */
-	function render(root, labels, values) {
+	function render(root, labels, values, showAxis) {
+		if (typeof showAxis === 'undefined') {
+			showAxis = true;
+		}
+
 		// Remove the loading content.
 		root.innerHTML = '';
 
@@ -103,8 +156,8 @@
 				width: fullWidth ? undefined : 5 * labels.length,
 				axisX: {
 					showGrid: false,
-					showLabel: false,
-					offset: 0,
+					showLabel: showAxis,
+					offset: showAxis ? 30 : 0,
 				},
 				axisY: {
 					showGrid: true,
@@ -237,7 +290,41 @@
 		}
 	}
 
-	// Abort if target element is not present.
+	/**
+	 * Render yearly table.
+	 *
+	 * @param {HTMLElement} table Root element.
+	 * @param {any}         data  Data from API.
+	 */
+	function renderYearlyTable(table, data) {
+		const tbody = table.querySelector('tbody');
+
+		tbody.innerHTML = '';
+
+		for (const year in data.visits) {
+			const row = document.createElement('TR');
+			let col = document.createElement('TH');
+			let sum = 0;
+			col.scope = 'row';
+			col.innerText = year;
+			row.appendChild(col);
+
+			for (let month = 1; month <= 12; month++) {
+				col = document.createElement('TD');
+				col.innerText = data.visits[year][month - 1] || '-';
+				row.appendChild(col);
+				sum += data.visits[year][month - 1] || 0;
+			}
+
+			col = document.createElement('TD');
+			col.innerText = sum;
+			row.appendChild(col);
+
+			tbody.insertBefore(row, tbody.firstChild);
+		}
+	}
+
+	// Abort if config or target element is not present.
 	if (chartElem) {
 		// Bind update function to "refresh" button.
 		if (refreshBtn) {
@@ -251,5 +338,27 @@
 
 		// Initial update.
 		updateDashboard(false);
+	}
+
+	if (chartElemMonthly) {
+		loadMonthly()
+			.then((data) => {
+				renderMonthly(chartElemMonthly, data);
+
+				if (chartElemYearly) {
+					renderYearly(chartElemYearly, data);
+				}
+
+				if (yearlyTable) {
+					renderYearlyTable(yearlyTable, data);
+				}
+			})
+			.catch(() => {
+				// Failed to load.
+				chartElem.innerHTML =
+					'<p>' +
+					wp.i18n.__('Error loading data.', 'statify') +
+					'</p>';
+			});
 	}
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -16,9 +16,11 @@
 	const chartElemMonthly = document.getElementById('statify_chart_monthly');
 	const chartElemYearly = document.getElementById('statify_chart_yearly');
 	const chartElemContent = document.getElementById('statify_chart_content');
+	const chartElemReferrer = document.getElementById('statify_chart_referrer');
 	const yearlyTable = document.getElementById('statify-table-yearly');
 	const dailyTable = document.getElementById('statify-table-daily');
 	const contentTable = document.getElementById('statify-table-posts');
+	const referrersTable = document.getElementById('statify-table-referrer');
 
 	// Controls.
 	const postInput = document.getElementById('statify-dashboard-post');
@@ -120,6 +122,28 @@
 		return wp.apiFetch({
 			path:
 				'/statify/v1/stats/posts' + (param.size > 0 ? '?' + param : ''),
+		});
+	}
+
+	/**
+	 * Load statistics per referrer.
+	 *
+	 * @return {Promise<Array<{count: number, host: string, url: string}>>} Data promise from API.
+	 */
+	function loadPerReferrer() {
+		const param = new URLSearchParams();
+		const search = new URLSearchParams(window.location.search);
+		['post', 'start', 'end'].forEach((p) => {
+			const v = search.get(p);
+			if (v) {
+				param.set(p, v);
+			}
+		});
+
+		return wp.apiFetch({
+			path:
+				'/statify/v1/stats/referrers' +
+				(param.size > 0 ? '?' + param : ''),
 		});
 	}
 
@@ -617,6 +641,52 @@
 	}
 
 	/**
+	 * Render referrers table.
+	 *
+	 * @param {HTMLTableElement}                                  table Root element.
+	 * @param {Array<{count: number, host: string, url: string}>} data  Data from API.
+	 */
+	function renderReferrersTable(table, data) {
+		const tbody = table.querySelector('tbody');
+		const sumRow = table.querySelectorAll('tfoot > tr > td');
+		const rows = Array.from(tbody.querySelectorAll('tr'));
+
+		const total = data.map((d) => d.count).reduce((a, b) => a + b, 0);
+
+		data.forEach((d, idx) => {
+			const row = document.createElement('TR');
+			let col = document.createElement('TD');
+			const link = document.createElement('A');
+			link.href = d.url;
+			link.innerText = d.host;
+			col.append(link);
+			row.appendChild(col);
+			col = document.createElement('TD');
+			col.classList.add('right');
+			col.innerText = d.count.toString();
+			row.appendChild(col);
+			col = document.createElement('TD');
+			col.classList.add('right');
+			col.innerText = ((d.count / total) * 100).toFixed(2) + ' %';
+			row.appendChild(col);
+
+			if (rows.length > idx) {
+				tbody.replaceChild(row, rows[idx]);
+			} else {
+				tbody.appendChild(row);
+			}
+		});
+		for (let i = data.length; i < rows.length; i++) {
+			tbody.removeChild(rows[i]);
+		}
+
+		sumRow[sumRow.length - 2].innerText = total;
+		sumRow[sumRow.length - 1].innerText = '100.00 %';
+
+		addExportButton(table);
+	}
+
+	/**
 	 * Convert daily to monthly data.
 	 *
 	 * @param {{[key: string]: number}} data Daily data.
@@ -695,6 +765,17 @@
 				const labels = data.map((d) => d.title);
 				const values = data.map((d) => d.count);
 				renderBarChart(chartElemContent, labels, values, true);
+			}
+		});
+	} else if (referrersTable) {
+		loadPerReferrer().then((data) => {
+			renderReferrersTable(referrersTable, data);
+			if (chartElemReferrer) {
+				// Limit number of records.
+				data = data.slice(0, 24);
+				const labels = data.map((d) => d.host);
+				const values = data.map((d) => d.count);
+				renderBarChart(chartElemReferrer, labels, values, true);
 			}
 		});
 	}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -18,6 +18,10 @@
 	const yearlyTable = document.getElementById('statify-table-yearly');
 	const dailyTable = document.getElementById('statify-table-daily');
 
+	// Controls.
+	const postInput = document.getElementById('statify-dashboard-post');
+	const postList = document.getElementById('statify-dashboard-posts');
+
 	/**
 	 * Update the dashboard widget
 	 *
@@ -85,8 +89,12 @@
 	 * @return {Promise<{visits: {[key: string]: {[key: string]: number}}}>} Data promise from API.
 	 */
 	function loadMonthly() {
-		// Load data from API.
-		return wp.apiFetch({ path: '/statify/v1/stats/extended?scope=month' });
+		let path = '/statify/v1/stats/extended?scope=month';
+		const post = new URLSearchParams(window.location.search).get('post');
+		if (post) {
+			path += '&post=' + encodeURIComponent(post);
+		}
+		return wp.apiFetch({ path });
 	}
 
 	/**
@@ -517,6 +525,18 @@
 					wp.i18n.__('Error loading data.', 'statify') +
 					'</p>';
 			});
+	}
+
+	if (postInput && postList) {
+		// Load data from API.
+		wp.apiFetch({ path: '/statify/v1/posts' }).then((data) =>
+			data.forEach((post) => {
+				const opt = document.createElement('option');
+				opt.value = post.url;
+				opt.innerText = post.title;
+				postList.appendChild(opt);
+			})
+		);
 	}
 
 	/**

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,33 +1,114 @@
 {
-	// Initialize
-	const chartElem = document.getElementById('statify_chart');
-	const referrerTable = document.querySelector(
-		'#statify_dashboard .table.referrer table tbody'
-	);
-	const targetTable = document.querySelector(
-		'#statify_dashboard .table.target table tbody'
-	);
-	const totalsTable = document.querySelector(
-		'#statify_dashboard .table.total table tbody'
-	);
-	const refreshBtn = document.getElementById('statify_refresh');
+	// Initialize DOM elements.
+	const charts = {
+		// Dashboard Widget.
+		dashboard: document.getElementById('statify_chart'),
+		// Extended Evaluation.
+		daily: document.getElementById('statify_chart_daily'),
+		monthly: document.getElementById('statify_chart_monthly'),
+		yearly: document.getElementById('statify_chart_yearly'),
+		content: document.getElementById('statify_chart_content'),
+		referrer: document.getElementById('statify_chart_referrer'),
+	};
+	const tables = {
+		// Dashboard Widget.
+		referrer: document.querySelector(
+			'#statify_dashboard .table.referrer table tbody'
+		),
+		target: document.querySelector(
+			'#statify_dashboard .table.target table tbody'
+		),
+		totals: document.querySelector(
+			'#statify_dashboard .table.total table tbody'
+		),
+		// Extended Evaluation.
+		yearly: document.getElementById('statify-table-yearly'),
+		daily: document.getElementById('statify-table-daily'),
+		content: document.getElementById('statify-table-posts'),
+		referrers: document.getElementById('statify-table-referrer'),
+	};
+	const controls = {
+		// Dashboard Widget.
+		refreshBtn: document.getElementById('statify_refresh'),
+		// Extended Evaluation.
+		postInput: document.getElementById('statify-dashboard-post'),
+		postList: document.getElementById('statify-dashboard-posts'),
+		dateRangeSelect: document.getElementById('statify-content-daterange'),
+	};
 
-	const chartElemDaily = document.getElementById('statify_chart_daily');
-	const chartElemMonthly = document.getElementById('statify_chart_monthly');
-	const chartElemYearly = document.getElementById('statify_chart_yearly');
-	const chartElemContent = document.getElementById('statify_chart_content');
-	const chartElemReferrer = document.getElementById('statify_chart_referrer');
-	const yearlyTable = document.getElementById('statify-table-yearly');
-	const dailyTable = document.getElementById('statify-table-daily');
-	const contentTable = document.getElementById('statify-table-posts');
-	const referrersTable = document.getElementById('statify-table-referrer');
+	/* ------------------------------------------------------------------ */
 
-	// Controls.
-	const postInput = document.getElementById('statify-dashboard-post');
-	const postList = document.getElementById('statify-dashboard-posts');
-	const dateRangeSelect = document.getElementById(
-		'statify-content-daterange'
-	);
+	// Render available charts and tables.
+	if (charts.daily) {
+		loadDaily(charts.daily.dataset.year).then((data) => {
+			renderDaily(charts.daily, data);
+
+			if (charts.monthly) {
+				renderMonthly(charts.monthly, dailyToMonthly(data), false);
+			}
+
+			if (tables.daily) {
+				renderDailyTable(tables.daily, data);
+			}
+		});
+	} else if (charts.monthly) {
+		loadMonthly()
+			.then((data) => {
+				renderMonthly(charts.monthly, data);
+
+				if (charts.yearly) {
+					renderYearly(charts.yearly, data);
+				}
+
+				if (tables.yearly) {
+					renderYearlyTable(tables.yearly, data);
+				}
+			})
+			.catch(() => {
+				// Failed to load.
+				charts.dashboard.innerHTML = `<p>${wp.i18n.__('Error loading data.', 'statify')}</p>`;
+			});
+	} else if (tables.content) {
+		loadPerPost().then((data) => {
+			renderContentTable(tables.content, data);
+			if (charts.content) {
+				// Limit number of records.
+				data = data.slice(0, 24);
+				const labels = data.map((d) => d.title);
+				const values = data.map((d) => d.count);
+				renderBarChart(charts.content, labels, values, true);
+			}
+		});
+	} else if (tables.referrers) {
+		loadPerReferrer().then((data) => {
+			renderReferrersTable(tables.referrers, data);
+			if (charts.referrer) {
+				// Limit number of records.
+				data = data.slice(0, 24);
+				const labels = data.map((d) => d.host);
+				const values = data.map((d) => d.count);
+				renderBarChart(charts.referrer, labels, values, true);
+			}
+		});
+	}
+
+	// Augment available controls.
+	if (controls.postInput && controls.postList) {
+		fetchData('posts').then((data) =>
+			data.forEach((post) => {
+				const opt = document.createElement('option');
+				opt.value = post.url;
+				opt.innerText = post.title;
+				controls.postList.appendChild(opt);
+			})
+		);
+	}
+
+	if (controls.dateRangeSelect) {
+		augmentDateRangeControls();
+	}
+
+	/* ------------------------------------------------------------------ */
 
 	/**
 	 * Update the dashboard widget
@@ -36,43 +117,39 @@
 	 */
 	function updateDashboard(refresh) {
 		// Disable refresh button.
-		if (refreshBtn) {
-			refreshBtn.disabled = true;
+		if (controls.refreshBtn) {
+			controls.refreshBtn.disabled = true;
 		}
 
 		// Load data from API.
-		wp.apiFetch({
-			path: '/statify/v1/stats' + (refresh ? '?refresh=1' : ''),
-		})
+		fetchData('stats', refresh ? 'refresh=1' : null)
 			.then((data) => {
 				const labels = Object.keys(data.visits);
 				const values = Object.values(data.visits);
 
-				render(chartElem, labels, values, false);
+				render(charts.dashboard, labels, values, false);
 
 				// Render top lists.
-				if (referrerTable) {
-					renderTopList(referrerTable, data.referrer);
+				if (tables.referrer) {
+					renderTopList(tables.referrer, data.referrer);
 				}
-				if (targetTable) {
-					renderTopList(targetTable, data.target);
-				}
-
-				if (totalsTable) {
-					renderTotals(totalsTable, data.totals);
+				if (tables.target) {
+					renderTopList(tables.target, data.target);
 				}
 
-				// Re-enable refresh button.
-				if (refreshBtn) {
-					refreshBtn.disabled = false;
+				if (tables.totals) {
+					renderTotals(tables.totals, data.totals);
 				}
 			})
 			.catch(() => {
 				// Failed to load.
-				chartElem.innerHTML =
-					'<p>' +
-					wp.i18n.__('Error loading data.', 'statify') +
-					'</p>';
+				charts.dashboard.innerHTML = `<p>${wp.i18n.__('Error loading data.', 'statify')}</p>`;
+			})
+			.finally(() => {
+				// Re-enable refresh button.
+				if (controls.refreshBtn) {
+					controls.refreshBtn.disabled = false;
+				}
 			});
 	}
 
@@ -84,10 +161,10 @@
 	 * @return {Promise<{[key: string]: number}>} Data promise from API.
 	 */
 	function loadDaily(year) {
-		// Load data from API.
-		return wp.apiFetch({
-			path: `/statify/v1/stats/extended?scope=day&year=${encodeURIComponent(year)}`,
-		});
+		return fetchData(
+			'stats/extended',
+			new URLSearchParams({ scope: 'day', year })
+		);
 	}
 
 	/**
@@ -96,12 +173,12 @@
 	 * @return {Promise<{visits: {[key: string]: {[key: string]: number}}}>} Data promise from API.
 	 */
 	function loadMonthly() {
-		let path = '/statify/v1/stats/extended?scope=month';
+		const param = { scope: 'month' };
 		const post = new URLSearchParams(window.location.search).get('post');
 		if (post) {
-			path += '&post=' + encodeURIComponent(post);
+			param.post = post;
 		}
-		return wp.apiFetch({ path });
+		return fetchData('stats/extended', param);
 	}
 
 	/**
@@ -119,10 +196,7 @@
 			}
 		});
 
-		return wp.apiFetch({
-			path:
-				'/statify/v1/stats/posts' + (param.size > 0 ? '?' + param : ''),
-		});
+		return fetchData('stats/posts', param);
 	}
 
 	/**
@@ -140,11 +214,7 @@
 			}
 		});
 
-		return wp.apiFetch({
-			path:
-				'/statify/v1/stats/referrers' +
-				(param.size > 0 ? '?' + param : ''),
-		});
+		return fetchData('stats/referrers', param);
 	}
 
 	/**
@@ -221,15 +291,14 @@
 		showAxis = true,
 		labelInterpolationFnc = (l) => l
 	) {
-		// Remove the loading content.
+		// Remove the loading content or existing chart.
 		root.innerHTML = '';
 
 		// Adjust display according if there are too many values to display readable.
 		let fullWidth = true;
 		let pointRadius = 4;
 		if (labels.length === 0) {
-			root.innerHTML =
-				'<p>' + wp.i18n.__('No data available.', 'statify') + '</p>';
+			root.innerHTML = `<p>${wp.i18n.__('No data available.', 'statify')}</p>`;
 			return;
 		} else if (root.clientWidth < labels.length * 4) {
 			// Make chart scrollable, if 2px points are overlapping.
@@ -327,8 +396,7 @@
 		root.innerHTML = '';
 
 		if (labels.length === 0) {
-			root.innerHTML =
-				'<p>' + wp.i18n.__('No data available.', 'statify') + '</p>';
+			root.innerHTML = `<p>${wp.i18n.__('No data available.', 'statify')}</p>`;
 			return;
 		}
 
@@ -365,8 +433,6 @@
 			{
 				low: 0,
 				showArea: true,
-				// fullWidth: true,
-				// width: fullWidth ? undefined : 5 * labels.length,
 				axisX: {
 					showGrid: false,
 				},
@@ -401,32 +467,15 @@
 	 * @param {{count: number, url: string, host: ?string}[]} data  Data to display.
 	 */
 	function renderTopList(table, data) {
-		// Get pre-existing rows.
-		const rows = table.querySelectorAll('tr');
-
-		// Update or append rows.
-		data.forEach((r, idx) => {
+		const rows = data.map((r) => {
 			const row = document.createElement('TR');
 			row.innerHTML =
-				'<td class="b">' +
-				r.count +
-				'</td>' +
-				'<td class="t"><a href="' +
-				r.url +
-				'" target="_blank"  rel="noopener noreferrer">' +
-				(r.host || r.url) +
-				'</td>';
-			if (rows.length > idx) {
-				table.replaceChild(row, rows[idx]);
-			} else {
-				table.appendChild(row);
-			}
+				`<td class="b">${r.count}</td>` +
+				`<td class="t"><a href="${r.url}" target="_blank"  rel="noopener noreferrer">${r.host || r.url}</td>`;
+			return row;
 		});
 
-		// Remove excess rows.
-		for (let i = data.length; i < rows.length; i++) {
-			table.removeChild(rows[i]);
-		}
+		updateTable(table, rows);
 	}
 
 	/**
@@ -436,25 +485,14 @@
 	 * @param {{alltime: number, since: string, today: number}} data  Totals data.
 	 */
 	function renderTotals(table, data) {
-		const rows = table.querySelectorAll('tr');
-		let row = document.createElement('TR');
-		row.innerHTML =
-			'<td class="b">' +
-			data.today +
-			'</td>' +
-			'<td class="t">' +
-			wp.i18n.__('today', 'statify') +
-			'</td>';
-		if (rows.length > 0) {
-			table.replaceChild(row, rows[0]);
-		} else {
-			table.appendChild(row);
-		}
-		row = document.createElement('TR');
-		row.innerHTML =
-			'<td class="b">' +
-			data.alltime +
-			'</td>' +
+		const rowToday = document.createElement('TR');
+		rowToday.innerHTML =
+			`<td class="b">${data.today}</td>` +
+			`<td class="t">${wp.i18n.__('today', 'statify')}</td>`;
+
+		const rowAll = document.createElement('TR');
+		rowAll.innerHTML =
+			`<td class="b">${data.alltime}</td>` +
 			'<td class="t">' +
 			wp.i18n.sprintf(
 				/* translators: %s: Date. */
@@ -462,14 +500,8 @@
 				data.since
 			) +
 			'</td>';
-		if (rows.length > 1) {
-			table.replaceChild(row, rows[1]);
-		} else {
-			table.appendChild(row);
-		}
-		for (let i = 2; i < rows.length; i++) {
-			table.removeChild(rows[i]);
-		}
+
+		updateTable(table, [rowToday, rowAll]);
 	}
 
 	/**
@@ -521,10 +553,10 @@
 		const cols = rows.map((row) => Array.from(row.querySelectorAll('td')));
 		let out = cols.slice(0, 31);
 
-		const sum = Array(12).fill(0);
-		const vls = Array(12).fill(0);
-		const min = Array(12).fill(Number.MAX_SAFE_INTEGER);
-		const max = Array(12).fill(0);
+		const sum = new Array(12).fill(0);
+		const vls = new Array(12).fill(0);
+		const min = new Array(12).fill(Number.MAX_SAFE_INTEGER);
+		const max = new Array(12).fill(0);
 
 		for (const [day, count] of Object.entries(data)) {
 			const d = new Date(day);
@@ -594,12 +626,11 @@
 	function renderContentTable(table, data) {
 		const tbody = table.querySelector('tbody');
 		const sumRow = table.querySelectorAll('tfoot > tr > td');
-		const rows = Array.from(tbody.querySelectorAll('tr'));
 		const showType = table.querySelectorAll('thead > tr > th').length > 4;
 
 		const total = data.map((d) => d.count).reduce((a, b) => a + b, 0);
 
-		data.forEach((d, idx) => {
+		const rows = data.map((d) => {
 			const row = document.createElement('TR');
 			let col = document.createElement('TD');
 			const link = document.createElement('A');
@@ -624,15 +655,10 @@
 			col.innerText = ((d.count / total) * 100).toFixed(2) + ' %';
 			row.appendChild(col);
 
-			if (rows.length > idx) {
-				tbody.replaceChild(row, rows[idx]);
-			} else {
-				tbody.appendChild(row);
-			}
+			return row;
 		});
-		for (let i = data.length; i < rows.length; i++) {
-			tbody.removeChild(rows[i]);
-		}
+
+		updateTable(tbody, rows);
 
 		sumRow[sumRow.length - 2].innerText = total;
 		sumRow[sumRow.length - 1].innerText = '100.00 %';
@@ -649,11 +675,10 @@
 	function renderReferrersTable(table, data) {
 		const tbody = table.querySelector('tbody');
 		const sumRow = table.querySelectorAll('tfoot > tr > td');
-		const rows = Array.from(tbody.querySelectorAll('tr'));
 
 		const total = data.map((d) => d.count).reduce((a, b) => a + b, 0);
 
-		data.forEach((d, idx) => {
+		const rows = data.map((d) => {
 			const row = document.createElement('TR');
 			let col = document.createElement('TD');
 			const link = document.createElement('A');
@@ -669,21 +694,39 @@
 			col.classList.add('right');
 			col.innerText = ((d.count / total) * 100).toFixed(2) + ' %';
 			row.appendChild(col);
-
-			if (rows.length > idx) {
-				tbody.replaceChild(row, rows[idx]);
-			} else {
-				tbody.appendChild(row);
-			}
+			return row;
 		});
-		for (let i = data.length; i < rows.length; i++) {
-			tbody.removeChild(rows[i]);
-		}
+
+		updateTable(tbody, rows);
 
 		sumRow[sumRow.length - 2].innerText = total;
 		sumRow[sumRow.length - 1].innerText = '100.00 %';
 
 		addExportButton(table);
+	}
+
+	/**
+	 * Replace or append table rows.
+	 *
+	 * @param {HTMLTableElement|HTMLTableSectionElement} table   Target table or table body.
+	 * @param {HTMLTableRowElement[]}                    newRows New row elements.
+	 */
+	function updateTable(table, newRows) {
+		const existingRows = table.querySelectorAll('tr');
+
+		// Replace existing rows
+		newRows.forEach((newRow, idx) => {
+			if (idx < existingRows.length) {
+				table.replaceChild(newRow, existingRows[idx]);
+			} else {
+				table.appendChild(newRow);
+			}
+		});
+
+		// Remove excess rows
+		for (let i = newRows.length; i < existingRows.length; i++) {
+			existingRows[i].remove();
+		}
 	}
 
 	/**
@@ -709,10 +752,10 @@
 	}
 
 	// Abort if config or target element is not present.
-	if (chartElem) {
+	if (charts.dashboard) {
 		// Bind update function to "refresh" button.
-		if (refreshBtn) {
-			refreshBtn.addEventListener('click', (evt) => {
+		if (controls.refreshBtn) {
+			controls.refreshBtn.addEventListener('click', (evt) => {
 				evt.preventDefault();
 				updateDashboard(true);
 
@@ -722,78 +765,6 @@
 
 		// Initial update.
 		updateDashboard(false);
-	}
-
-	if (chartElemDaily) {
-		loadDaily(chartElemDaily.dataset.year).then((data) => {
-			renderDaily(chartElemDaily, data);
-
-			if (chartElemMonthly) {
-				renderMonthly(chartElemMonthly, dailyToMonthly(data), false);
-			}
-
-			if (dailyTable) {
-				renderDailyTable(dailyTable, data);
-			}
-		});
-	} else if (chartElemMonthly) {
-		loadMonthly()
-			.then((data) => {
-				renderMonthly(chartElemMonthly, data);
-
-				if (chartElemYearly) {
-					renderYearly(chartElemYearly, data);
-				}
-
-				if (yearlyTable) {
-					renderYearlyTable(yearlyTable, data);
-				}
-			})
-			.catch(() => {
-				// Failed to load.
-				chartElem.innerHTML =
-					'<p>' +
-					wp.i18n.__('Error loading data.', 'statify') +
-					'</p>';
-			});
-	} else if (contentTable) {
-		loadPerPost().then((data) => {
-			renderContentTable(contentTable, data);
-			if (chartElemContent) {
-				// Limit number of records.
-				data = data.slice(0, 24);
-				const labels = data.map((d) => d.title);
-				const values = data.map((d) => d.count);
-				renderBarChart(chartElemContent, labels, values, true);
-			}
-		});
-	} else if (referrersTable) {
-		loadPerReferrer().then((data) => {
-			renderReferrersTable(referrersTable, data);
-			if (chartElemReferrer) {
-				// Limit number of records.
-				data = data.slice(0, 24);
-				const labels = data.map((d) => d.host);
-				const values = data.map((d) => d.count);
-				renderBarChart(chartElemReferrer, labels, values, true);
-			}
-		});
-	}
-
-	if (postInput && postList) {
-		// Load data from API.
-		wp.apiFetch({ path: '/statify/v1/posts' }).then((data) =>
-			data.forEach((post) => {
-				const opt = document.createElement('option');
-				opt.value = post.url;
-				opt.innerText = post.title;
-				postList.appendChild(opt);
-			})
-		);
-	}
-
-	if (dateRangeSelect) {
-		augmentDateRangeControls();
 	}
 
 	/**
@@ -835,6 +806,10 @@
 		table.after(exportBtn);
 	}
 
+	/**
+	 * Augment date range controls.
+	 * Fill start/end based on selected range and revert to "custom" when changed manually.
+	 */
 	function augmentDateRangeControls() {
 		const start = document.getElementById('statify-content-datestart');
 		const end = document.getElementById('statify-content-dateend');
@@ -842,7 +817,7 @@
 			const isoDate = (y, m, d) =>
 				new Date(Date.UTC(y, m, d)).toISOString().split('T')[0];
 
-			dateRangeSelect.addEventListener('change', (evt) => {
+			controls.dateRangeSelect.addEventListener('change', (evt) => {
 				const now = new Date(),
 					y = now.getFullYear(),
 					m = now.getMonth(),
@@ -911,11 +886,24 @@
 			});
 
 			start.addEventListener('change', () => {
-				dateRangeSelect.value = 'custom';
+				controls.dateRangeSelect.value = 'custom';
 			});
 			end.addEventListener('change', () => {
-				dateRangeSelect.value = 'custom';
+				controls.dateRangeSelect.value = 'custom';
 			});
 		}
+	}
+
+	/**
+	 * Fetch data from Statify API.
+	 *
+	 * @param {string}                                             path  Relative API path.
+	 * @param {string|Record<string, string>|URLSearchParams|null} param Parameters (optional).
+	 * @return {Promise<any>} Response promise.
+	 */
+	function fetchData(path, param = undefined) {
+		return wp.apiFetch({
+			path: `/statify/v1/${path}${param ? '?' + new URLSearchParams(param) : ''}`,
+		});
 	}
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -15,12 +15,17 @@
 	const chartElemDaily = document.getElementById('statify_chart_daily');
 	const chartElemMonthly = document.getElementById('statify_chart_monthly');
 	const chartElemYearly = document.getElementById('statify_chart_yearly');
+	const chartElemContent = document.getElementById('statify_chart_content');
 	const yearlyTable = document.getElementById('statify-table-yearly');
 	const dailyTable = document.getElementById('statify-table-daily');
+	const contentTable = document.getElementById('statify-table-posts');
 
 	// Controls.
 	const postInput = document.getElementById('statify-dashboard-post');
 	const postList = document.getElementById('statify-dashboard-posts');
+	const dateRangeSelect = document.getElementById(
+		'statify-content-daterange'
+	);
 
 	/**
 	 * Update the dashboard widget
@@ -70,7 +75,7 @@
 	}
 
 	/**
-	 * Render monthly statistics.
+	 * Load monthly statistics.
 	 *
 	 * @param {number} year Year to load data for.
 	 *
@@ -84,7 +89,7 @@
 	}
 
 	/**
-	 * Render monthly statistics.
+	 * Load monthly statistics.
 	 *
 	 * @return {Promise<{visits: {[key: string]: {[key: string]: number}}}>} Data promise from API.
 	 */
@@ -95,6 +100,27 @@
 			path += '&post=' + encodeURIComponent(post);
 		}
 		return wp.apiFetch({ path });
+	}
+
+	/**
+	 * Load statistics per post.
+	 *
+	 * @return {Promise<Array<{count: number, title: string, type: string, typeName: string, url: string}>>} Data promise from API.
+	 */
+	function loadPerPost() {
+		const param = new URLSearchParams();
+		const search = new URLSearchParams(window.location.search);
+		['type', 'start', 'end'].forEach((p) => {
+			const v = search.get(p);
+			if (v) {
+				param.set(p, v);
+			}
+		});
+
+		return wp.apiFetch({
+			path:
+				'/statify/v1/stats/posts' + (param.size > 0 ? '?' + param : ''),
+		});
 	}
 
 	/**
@@ -248,8 +274,8 @@
 						'ct:value': wp.i18n.sprintf(
 							/* translators: %s: Number of page views. */
 							wp.i18n._n(
-								'%s Page view',
-								'%s Page views',
+								'%s view',
+								'%s views',
 								d.value.y,
 								'statify'
 							),
@@ -262,6 +288,86 @@
 				d.element.replace(circle);
 			}
 		});
+	}
+
+	/**
+	 * Render bar chart.
+	 *
+	 * @param {HTMLElement} root          Root element.
+	 * @param {string[]}    labels        Labels.
+	 * @param {number[]}    values        Values.
+	 * @param {boolean}     numericLabels Transform labels into numbers and add legend? (default: false)
+	 */
+	function renderBarChart(root, labels, values, numericLabels = false) {
+		// Remove the loading content.
+		root.innerHTML = '';
+
+		if (labels.length === 0) {
+			root.innerHTML =
+				'<p>' + wp.i18n.__('No data available.', 'statify') + '</p>';
+			return;
+		}
+
+		if (numericLabels) {
+			const container = root.parentElement;
+			let legend = container.querySelector('.statify-legend');
+			if (legend) {
+				legend.innerHTML = '';
+			} else {
+				legend = document.createElement('OL');
+				legend.classList.add('statify-legend');
+				container.appendChild(legend);
+			}
+
+			labels.forEach((l) => {
+				const li = document.createElement('LI');
+				li.innerText = l;
+				legend.appendChild(li);
+			});
+
+			values = values.map((v, i) => {
+				return { meta: labels[i], value: v };
+			});
+			labels = labels.map((l, i) => i + 1);
+		}
+
+		// Draw chart.
+		new Chartist.BarChart(
+			root,
+			{
+				labels,
+				series: [values],
+			},
+			{
+				low: 0,
+				showArea: true,
+				// fullWidth: true,
+				// width: fullWidth ? undefined : 5 * labels.length,
+				axisX: {
+					showGrid: false,
+				},
+				axisY: {
+					showGrid: true,
+					showLabel: true,
+					low: 0,
+					onlyInteger: true,
+				},
+				plugins: [
+					Chartist.plugins.tooltip({
+						appendToBody: true,
+						anchorToPoint: true,
+						class: 'statify-chartist-tooltip',
+						transformTooltipTextFnc(y) {
+							return wp.i18n.sprintf(
+								/* translators: %s: Number of page views. */
+								wp.i18n._n('%s view', '%s views', y, 'statify'),
+								y
+							);
+						},
+					}),
+				],
+			}
+		);
 	}
 
 	/**
@@ -456,6 +562,61 @@
 	}
 
 	/**
+	 * Render content table.
+	 *
+	 * @param {HTMLTableElement}                                                                   table Root element.
+	 * @param {Array<{count: number, title: string, type: string, typeName: string, url: string}>} data  Data from API.
+	 */
+	function renderContentTable(table, data) {
+		const tbody = table.querySelector('tbody');
+		const sumRow = table.querySelectorAll('tfoot > tr > td');
+		const rows = Array.from(tbody.querySelectorAll('tr'));
+		const showType = table.querySelectorAll('thead > tr > th').length > 4;
+
+		const total = data.map((d) => d.count).reduce((a, b) => a + b, 0);
+
+		data.forEach((d, idx) => {
+			const row = document.createElement('TR');
+			let col = document.createElement('TD');
+			const link = document.createElement('A');
+			link.href = d.url;
+			link.innerText = d.title;
+			col.append(link);
+			row.appendChild(col);
+			col = document.createElement('TD');
+			col.innerText = d.url;
+			row.appendChild(col);
+			if (showType) {
+				col = document.createElement('TD');
+				col.innerText = d.typeName;
+				row.appendChild(col);
+			}
+			col = document.createElement('TD');
+			col.classList.add('right');
+			col.innerText = d.count.toString();
+			row.appendChild(col);
+			col = document.createElement('TD');
+			col.classList.add('right');
+			col.innerText = ((d.count / total) * 100).toFixed(2) + ' %';
+			row.appendChild(col);
+
+			if (rows.length > idx) {
+				tbody.replaceChild(row, rows[idx]);
+			} else {
+				tbody.appendChild(row);
+			}
+		});
+		for (let i = data.length; i < rows.length; i++) {
+			tbody.removeChild(rows[i]);
+		}
+
+		sumRow[sumRow.length - 2].innerText = total;
+		sumRow[sumRow.length - 1].innerText = '100.00 %';
+
+		addExportButton(table);
+	}
+
+	/**
 	 * Convert daily to monthly data.
 	 *
 	 * @param {{[key: string]: number}} data Daily data.
@@ -525,6 +686,17 @@
 					wp.i18n.__('Error loading data.', 'statify') +
 					'</p>';
 			});
+	} else if (contentTable) {
+		loadPerPost().then((data) => {
+			renderContentTable(contentTable, data);
+			if (chartElemContent) {
+				// Limit number of records.
+				data = data.slice(0, 24);
+				const labels = data.map((d) => d.title);
+				const values = data.map((d) => d.count);
+				renderBarChart(chartElemContent, labels, values, true);
+			}
+		});
 	}
 
 	if (postInput && postList) {
@@ -537,6 +709,10 @@
 				postList.appendChild(opt);
 			})
 		);
+	}
+
+	if (dateRangeSelect) {
+		augmentDateRangeControls();
 	}
 
 	/**
@@ -576,5 +752,89 @@
 					.join('\r\n');
 		});
 		table.after(exportBtn);
+	}
+
+	function augmentDateRangeControls() {
+		const start = document.getElementById('statify-content-datestart');
+		const end = document.getElementById('statify-content-dateend');
+		if (start && end) {
+			const isoDate = (y, m, d) =>
+				new Date(Date.UTC(y, m, d)).toISOString().split('T')[0];
+
+			dateRangeSelect.addEventListener('change', (evt) => {
+				const now = new Date(),
+					y = now.getFullYear(),
+					m = now.getMonth(),
+					d = now.getDate(),
+					day = now.getDay(),
+					monday = d - day + (day === 0 ? -6 : 1);
+
+				switch (evt.target.value) {
+					case '':
+						start.value = '';
+						end.value = '';
+						break;
+					case 'lastYear':
+						start.value = isoDate(y - 1, 0, 1);
+						end.value = isoDate(y - 1, 11, 31);
+						break;
+					case 'lastWeek':
+						start.value = isoDate(y, m, monday - 7);
+						end.value = isoDate(y, m, monday - 1);
+						break;
+					case 'yesterday':
+						start.value = isoDate(y, m, d - 1);
+						end.value = isoDate(y, m, d - 1);
+						break;
+					case 'today':
+						start.value = isoDate(y, m, d);
+						end.value = isoDate(y, m, d);
+						break;
+					case 'thisWeek':
+						start.value = isoDate(y, m, monday);
+						end.value = isoDate(y, m, monday + 6);
+						break;
+					case 'last28days':
+						start.value = isoDate(y, m, d - 27);
+						end.value = isoDate(y, m, d);
+						break;
+					case 'lastMonth':
+						start.value = isoDate(y, m - 1, 1);
+						end.value = isoDate(y, m, 0);
+						break;
+					case 'thisMonth':
+						start.value = isoDate(y, m, 1);
+						end.value = isoDate(y, m + 1, 0);
+						break;
+					case '1stQuarter':
+						start.value = isoDate(y, 1, 1);
+						end.value = isoDate(y, 2, 31);
+						break;
+					case '2ndQuarter':
+						start.value = isoDate(y, 3, 1);
+						end.value = isoDate(y, 5, 30);
+						break;
+					case '3rdQuarter':
+						start.value = isoDate(y, 6, 1);
+						end.value = isoDate(y, 8, 30);
+						break;
+					case '4thQuarter':
+						start.value = isoDate(y, 9, 1);
+						end.value = isoDate(y, 11, 31);
+						break;
+					case 'thisYear':
+						start.value = isoDate(y, 0, 1);
+						end.value = isoDate(y, 11, 31);
+						break;
+				}
+			});
+
+			start.addEventListener('change', () => {
+				dateRangeSelect.value = 'custom';
+			});
+			end.addEventListener('change', () => {
+				dateRangeSelect.value = 'custom';
+			});
+		}
 	}
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -246,18 +246,35 @@
 	 * @param {boolean}                                            showYear Show year in label? (default: true)
 	 */
 	function renderMonthly(root, data, showYear = true) {
-		const labels = Object.keys(data.visits).flatMap((y) =>
-			Object.keys(data.visits[y]).map(
-				(m) =>
-					statifyDashboard.i18n.months[m - 1] +
-					(showYear ? ' ' + y : '')
-			)
-		);
 		const values = Object.values(data.visits).flatMap((y) =>
 			Object.values(y)
 		);
 
-		render(root, labels, values);
+		let labelFunc = (l) => l;
+		let labels;
+		if (showYear && Object.keys(data.visits).length > 2) {
+			labels = Object.keys(data.visits).flatMap((y) =>
+				Object.keys(data.visits[y]).map((m) => `${y}-${m}-01`)
+			);
+			labelFunc = (date) => {
+				const d = new Date(date);
+				const m = d.getMonth();
+				if (m === 0) {
+					return String(d.getFullYear());
+				}
+				return '';
+			};
+		} else {
+			labels = Object.keys(data.visits).flatMap((y) =>
+				Object.keys(data.visits[y]).map(
+					(m) =>
+						statifyDashboard.i18n.months[m - 1] +
+						(showYear ? ' ' + y : '')
+				)
+			);
+		}
+
+		render(root, labels, values, true, labelFunc);
 	}
 
 	/**

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -12,9 +12,11 @@
 	);
 	const refreshBtn = document.getElementById('statify_refresh');
 
+	const chartElemDaily = document.getElementById('statify_chart_daily');
 	const chartElemMonthly = document.getElementById('statify_chart_monthly');
 	const chartElemYearly = document.getElementById('statify_chart_yearly');
 	const yearlyTable = document.getElementById('statify-table-yearly');
+	const dailyTable = document.getElementById('statify-table-daily');
 
 	/**
 	 * Update the dashboard widget
@@ -66,6 +68,20 @@
 	/**
 	 * Render monthly statistics.
 	 *
+	 * @param {number} year Year to load data for.
+	 *
+	 * @return {Promise<{[key: string]: number}>} Data promise from API.
+	 */
+	function loadDaily(year) {
+		// Load data from API.
+		return wp.apiFetch({
+			path: `/statify/v1/stats/extended?scope=day&year=${encodeURIComponent(year)}`,
+		});
+	}
+
+	/**
+	 * Render monthly statistics.
+	 *
 	 * @return {Promise<{visits: {[key: string]: {[key: string]: number}}}>} Data promise from API.
 	 */
 	function loadMonthly() {
@@ -74,15 +90,39 @@
 	}
 
 	/**
+	 * Render daily statistics.
+	 *
+	 * @param {HTMLElement}             root Root element.
+	 * @param {{[key: string]: number}} data Data from API.
+	 */
+	function renderDaily(root, data) {
+		const labels = Object.keys(data);
+		const values = Object.values(data);
+		const usedLabels = [];
+
+		render(root, labels, values, true, (day) => {
+			const mon = new Date(day).getMonth();
+			if (usedLabels.includes(mon)) {
+				return '';
+			}
+			usedLabels.push(mon);
+			return statifyDashboard.i18n.months[mon];
+		});
+	}
+
+	/**
 	 * Render monthly statistics.
 	 *
-	 * @param {HTMLElement}                                        root Root element.
-	 * @param {{visits: {[key: string]: {[key: string]: number}}}} data Data from API.
+	 * @param {HTMLElement}                                        root     Root element.
+	 * @param {{visits: {[key: string]: {[key: string]: number}}}} data     Data from API.
+	 * @param {boolean}                                            showYear Show year in label? (default: true)
 	 */
-	function renderMonthly(root, data) {
+	function renderMonthly(root, data, showYear = true) {
 		const labels = Object.keys(data.visits).flatMap((y) =>
 			Object.keys(data.visits[y]).map(
-				(m) => statifyDashboard.i18n.months[m - 1] + ' ' + y
+				(m) =>
+					statifyDashboard.i18n.months[m - 1] +
+					(showYear ? ' ' + y : '')
 			)
 		);
 		const values = Object.values(data.visits).flatMap((y) =>
@@ -110,16 +150,19 @@
 	/**
 	 * Render statistics chart.
 	 *
-	 * @param {HTMLElement} root     Root element.
-	 * @param {string[]}    labels   Labels.
-	 * @param {number[]}    values   Values.
-	 * @param {boolean}     showAxis Show X axis?
+	 * @param {HTMLElement}             root                  Root element.
+	 * @param {string[]}                labels                Labels.
+	 * @param {number[]}                values                Values.
+	 * @param {boolean}                 showAxis              Show X axis? (default: true)
+	 * @param {function(string):string} labelInterpolationFnc Label interpolation function. (optional)
 	 */
-	function render(root, labels, values, showAxis) {
-		if (typeof showAxis === 'undefined') {
-			showAxis = true;
-		}
-
+	function render(
+		root,
+		labels,
+		values,
+		showAxis = true,
+		labelInterpolationFnc = (l) => l
+	) {
 		// Remove the loading content.
 		root.innerHTML = '';
 
@@ -158,6 +201,7 @@
 					showGrid: false,
 					showLabel: showAxis,
 					offset: showAxis ? 30 : 0,
+					labelInterpolationFnc,
 				},
 				axisY: {
 					showGrid: true,
@@ -317,11 +361,107 @@
 			}
 
 			col = document.createElement('TD');
+			col.classList.add('statify-table-sum');
 			col.innerText = sum;
 			row.appendChild(col);
 
 			tbody.insertBefore(row, tbody.firstChild);
 		}
+	}
+
+	/**
+	 * Render yearly table.
+	 *
+	 * @param {HTMLElement} table Root element.
+	 * @param {any}         data  Data from API.
+	 */
+	function renderDailyTable(table, data) {
+		const rows = Array.from(table.querySelectorAll('tbody > tr'));
+		const cols = rows.map((row) => Array.from(row.querySelectorAll('td')));
+		let out = cols.slice(0, 31);
+
+		const sum = Array(12).fill(0);
+		const vls = Array(12).fill(0);
+		const min = Array(12).fill(Number.MAX_SAFE_INTEGER);
+		const max = Array(12).fill(0);
+
+		for (const [day, count] of Object.entries(data)) {
+			const d = new Date(day);
+			const m = d.getMonth();
+			sum[m] += count;
+			++vls[m];
+			min[m] = Math.min(min[m], count);
+			max[m] = Math.max(max[m], count);
+			out[d.getDate() - 1][m].innerText = count;
+		}
+
+		out =
+			cols[
+				rows.findIndex((row) =>
+					row.classList.contains('statify-table-sum')
+				)
+			];
+		const avg =
+			cols[
+				rows.findIndex((row) =>
+					row.classList.contains('statify-table-avg')
+				)
+			];
+		for (const [m, s] of sum.entries()) {
+			if (vls[m] > 0) {
+				out[m].innerText = s;
+				avg[m].innerText = Math.round(s / vls[m]);
+			} else {
+				out[m].innerText = '-';
+				avg[m].innerText = '-';
+			}
+		}
+
+		out =
+			cols[
+				rows.findIndex((row) =>
+					row.classList.contains('statify-table-min')
+				)
+			];
+		for (const [m, s] of min.entries()) {
+			out[m].innerText = vls[m] > 0 ? s : '-';
+		}
+
+		out =
+			cols[
+				rows.findIndex((row) =>
+					row.classList.contains('statify-table-max')
+				)
+			];
+		for (const [m, s] of max.entries()) {
+			out[m].innerText = vls[m] > 0 ? s : '-';
+		}
+
+		for (const row of rows) {
+			row.classList.remove('placeholder');
+		}
+	}
+
+	/**
+	 * Convert daily to monthly data.
+	 *
+	 * @param {{[key: string]: number}} data Daily data.
+	 * @return {{visits: {[key: string]: {[key: string]: number}}}} Monthly data.
+	 */
+	function dailyToMonthly(data) {
+		const monthly = { visits: {} };
+		for (const [day, count] of Object.entries(data)) {
+			const date = new Date(day);
+			const year = date.getFullYear();
+			const month = date.getMonth() + 1;
+
+			if (!(year in monthly.visits)) {
+				monthly.visits[year] = {};
+			}
+			monthly.visits[year][month] =
+				count + (monthly.visits[year][month] || 0);
+		}
+		return monthly;
 	}
 
 	// Abort if config or target element is not present.
@@ -340,7 +480,19 @@
 		updateDashboard(false);
 	}
 
-	if (chartElemMonthly) {
+	if (chartElemDaily) {
+		loadDaily(chartElemDaily.dataset.year).then((data) => {
+			renderDaily(chartElemDaily, data);
+
+			if (chartElemMonthly) {
+				renderMonthly(chartElemMonthly, dailyToMonthly(data), false);
+			}
+
+			if (dailyTable) {
+				renderDailyTable(dailyTable, data);
+			}
+		});
+	} else if (chartElemMonthly) {
 		loadMonthly()
 			.then((data) => {
 				renderMonthly(chartElemMonthly, data);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -367,13 +367,15 @@
 
 			tbody.insertBefore(row, tbody.firstChild);
 		}
+
+		addExportButton(table);
 	}
 
 	/**
 	 * Render yearly table.
 	 *
-	 * @param {HTMLElement} table Root element.
-	 * @param {any}         data  Data from API.
+	 * @param {HTMLTableElement} table Root element.
+	 * @param {any}              data  Data from API.
 	 */
 	function renderDailyTable(table, data) {
 		const rows = Array.from(table.querySelectorAll('tbody > tr'));
@@ -440,6 +442,8 @@
 		for (const row of rows) {
 			row.classList.remove('placeholder');
 		}
+
+		addExportButton(table);
 	}
 
 	/**
@@ -512,5 +516,44 @@
 					wp.i18n.__('Error loading data.', 'statify') +
 					'</p>';
 			});
+	}
+
+	/**
+	 * Add a CSV export button to a table.
+	 *
+	 * @param {HTMLTableElement} table Table to process
+	 */
+	function addExportButton(table) {
+		const exportBtn = document.createElement('a');
+		exportBtn.classList.add('button');
+		exportBtn.href = '#';
+
+		// Generate filename from table caption.
+		exportBtn.download =
+			statifyDashboard.i18n.sitename +
+			'-' +
+			table.caption.innerText.replaceAll(/\s+/g, '_') +
+			'-export-' +
+			new Date()
+				.toISOString()
+				.replace('T', '_')
+				.replaceAll(':', '-')
+				.substring(0, 16) +
+			'.csv';
+
+		// Generate CSV on demand.
+		exportBtn.innerText = wp.i18n.__('Export (CSV)', 'statify');
+		exportBtn.addEventListener('click', () => {
+			exportBtn.href =
+				'data:text/csv;charset=utf-8,' +
+				Array.from(table.rows)
+					.map((row) =>
+						Array.from(row.cells)
+							.map((col) => col.innerText)
+							.join(',')
+					)
+					.join('\r\n');
+		});
+		table.after(exportBtn);
 	}
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -355,7 +355,8 @@
 
 			for (let month = 1; month <= 12; month++) {
 				col = document.createElement('TD');
-				col.innerText = data.visits[year][month - 1] || '-';
+				col.innerText =
+					month in data.visits[year] ? data.visits[year][month] : '-';
 				row.appendChild(col);
 				sum += data.visits[year][month - 1] || 0;
 			}

--- a/statify.php
+++ b/statify.php
@@ -67,6 +67,7 @@ function statify_autoload( $class ) {
 		'Statify',
 		'Statify_Api',
 		'Statify_Backend',
+		'Statify_Evaluation',
 		'Statify_Frontend',
 		'Statify_Dashboard',
 		'Statify_Install',

--- a/tests/test-dashboard.php
+++ b/tests/test-dashboard.php
@@ -86,11 +86,11 @@ class Test_Dashboard extends WP_UnitTestCase {
 			'Unexpected control callback'
 		);
 		$this->assertNotFalse(
-			has_action( 'admin_print_styles', array( Statify_Dashboard::class, 'add_style' ) ),
+			has_action( 'admin_print_styles', array( Statify::class, 'add_style' ) ),
 			'Styles not added'
 		);
 		$this->assertNotFalse(
-			has_action( 'admin_print_scripts', array( Statify_Dashboard::class, 'add_js' ) ),
+			has_action( 'admin_print_scripts', array( Statify::class, 'add_js' ) ),
 			'Scripts not added'
 		);
 	}

--- a/tests/test-evaluation.php
+++ b/tests/test-evaluation.php
@@ -40,6 +40,7 @@ class Test_Evaluation extends WP_UnitTestCase {
 	 * Test views for all days.
 	 */
 	public function test_get_views_for_all_days() {
+		$this->insert_test_data( '2022-10-20', '', '/test/' );
 		$this->insert_test_data( '2023-03-23', '', '/', 3 );
 		$this->insert_test_data( '2023-03-23', '', '/test/' );
 		$this->insert_test_data( '2023-03-25', '', '/' );
@@ -47,17 +48,37 @@ class Test_Evaluation extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
+				'2022-10-20' => 1,
 				'2023-03-23' => 4,
 				'2023-03-25' => 3,
 			),
-			Statify_Evaluation::get_views_for_all_days()
+			Statify_Evaluation::get_views_for_all_days(),
+			'unexpected results without any filter'
+		);
+		self::assertSame(
+			array(
+				'2022-10-20' => 1,
+				'2023-03-23' => 1,
+				'2023-03-25' => 2,
+			),
+			Statify_Evaluation::get_views_for_all_days( 0, '/test/' ),
+			'unexpected results with post filter'
+		);
+		self::assertSame(
+			array(
+				'2023-03-23' => 4,
+				'2023-03-25' => 3,
+			),
+			Statify_Evaluation::get_views_for_all_days( 2023 ),
+			'unexpected results with year filter'
 		);
 		self::assertSame(
 			array(
 				'2023-03-23' => 1,
 				'2023-03-25' => 2,
 			),
-			Statify_Evaluation::get_views_for_all_days( '/test/' )
+			Statify_Evaluation::get_views_for_all_days( 2023, '/test/' ),
+			'unexpected results with year and post filter'
 		);
 	}
 

--- a/tests/test-evaluation.php
+++ b/tests/test-evaluation.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Statify evaluation tests.
+ *
+ * @package Statify
+ */
+
+/**
+ * Class Test_Evaluation.
+ * Tests for extended evaluation queries.
+ */
+class Test_Evaluation extends WP_UnitTestCase {
+	use Statify_Test_Support;
+
+	/**
+	 * Set up the test case.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// "Install" Statify, i.e. create tables and options.
+		Statify_Install::init();
+	}
+
+	/**
+	 * Test years.
+	 */
+	public function test_get_years() {
+		self::assertSame( array(), Statify_Evaluation::get_years() );
+		$this->insert_test_data( '2023-03-25' );
+		self::assertSame( array( 2023 ), Statify_Evaluation::get_years() );
+		$this->insert_test_data( '2023-03-24' );
+		$this->insert_test_data( '2022-03-04' );
+		$this->insert_test_data( '2024-05-06' );
+		$this->insert_test_data( '2020-01-02' );
+		self::assertSame( array( 2024, 2023, 2022, 2020 ), Statify_Evaluation::get_years() );
+	}
+
+	/**
+	 * Test views for all days.
+	 */
+	public function test_get_views_for_all_days() {
+		$this->insert_test_data( '2023-03-23', '', '/', 3 );
+		$this->insert_test_data( '2023-03-23', '', '/test/' );
+		$this->insert_test_data( '2023-03-25', '', '/' );
+		$this->insert_test_data( '2023-03-25', '', '/test/', 2 );
+
+		self::assertSame(
+			array(
+				'2023-03-23' => 4,
+				'2023-03-25' => 3,
+			),
+			Statify_Evaluation::get_views_for_all_days()
+		);
+		self::assertSame(
+			array(
+				'2023-03-23' => 1,
+				'2023-03-25' => 2,
+			),
+			Statify_Evaluation::get_views_for_all_days( '/test/' )
+		);
+	}
+
+	/**
+	 * Test views for all months.
+	 */
+	public function test_get_views_for_all_months() {
+		$this->insert_test_data( '2023-02-23', '', '/', 3 );
+		$this->insert_test_data( '2023-02-22', '', '/test/' );
+		$this->insert_test_data( '2023-03-24', '', '/' );
+		$this->insert_test_data( '2023-03-25', '', '/test/', 2 );
+
+		self::assertSame(
+			array(
+				'2023-02' => 4,
+				'2023-03' => 3,
+			),
+			Statify_Evaluation::get_views_for_all_months()
+		);
+		self::assertSame(
+			array(
+				'2023-02' => 1,
+				'2023-03' => 2,
+			),
+			Statify_Evaluation::get_views_for_all_months( '/test/' )
+		);
+	}
+
+	/**
+	 * Test views for all years.
+	 */
+	public function test_get_views_for_all_years() {
+		$this->insert_test_data( '2022-02-23', '', '/', 3 );
+		$this->insert_test_data( '2022-02-22', '', '/test/' );
+		$this->insert_test_data( '2023-03-24', '', '/' );
+		$this->insert_test_data( '2023-03-25', '', '/test/', 2 );
+
+		self::assertSame(
+			array(
+				'2022' => 4,
+				'2023' => 3,
+			),
+			Statify_Evaluation::get_views_for_all_years()
+		);
+		self::assertSame(
+			array(
+				'2022' => 1,
+				'2023' => 2,
+			),
+			Statify_Evaluation::get_views_for_all_years( '/test/' )
+		);
+	}
+
+	/**
+	 * Test views for most popular posts.
+	 */
+	public function test_get_views_of_most_popular_posts() {
+		$this->insert_test_data( '2023-03-22', '', '/' );
+		$this->insert_test_data( '2023-03-23', '', '/test/', 3 );
+		$this->insert_test_data( '2023-03-24', '', '/' );
+		$this->insert_test_data( '2023-03-25', '', '/foo/', 4 );
+
+		self::assertSame(
+			array(
+				array(
+					'count' => 4,
+					'url'   => '/foo/',
+				),
+				array(
+					'count' => 3,
+					'url'   => '/test/',
+				),
+				array(
+					'count' => 2,
+					'url'   => '/',
+				),
+			),
+			Statify_Evaluation::get_views_of_most_popular_posts()
+		);
+
+		self::assertSame(
+			array(
+				array(
+					'count' => 3,
+					'url'   => '/test/',
+				),
+				array(
+					'count' => 1,
+					'url'   => '/',
+				),
+			),
+			Statify_Evaluation::get_views_of_most_popular_posts( '2023-03-23', '2023-03-24' )
+		);
+	}
+
+	/**
+	 * Test views for all referrers.
+	 */
+	public function test_get_views_for_all_referrers() {
+		$this->insert_test_data( '2023-03-22', 'https://example.com', '/' );
+		$this->insert_test_data( '2023-03-23', 'https://example.com/foo', '/test/', 2 );
+		$this->insert_test_data( '2023-03-24', 'http://example.org', '/' );
+		$this->insert_test_data( '2023-03-24', '', '/' );
+		$this->insert_test_data( '2023-03-25', 'https://pluginkollektiv.de/', '/foo/', 4 );
+
+		self::assertSame(
+			array(
+				array(
+					'count' => 4,
+					'url'   => 'https://pluginkollektiv.de/',
+					'host'  => 'pluginkollektiv.de',
+				),
+				array(
+					'count' => 3,
+					'url'   => 'https://example.com',
+					'host'  => 'example.com',
+				),
+				array(
+					'count' => 1,
+					'url'   => 'http://example.org',
+					'host'  => 'example.org',
+				),
+			),
+			Statify_Evaluation::get_views_for_all_referrers()
+		);
+
+		self::assertSame(
+			array(
+				array(
+					'count' => 2,
+					'url'   => 'https://example.com/foo',
+					'host'  => 'example.com',
+				),
+				array(
+					'count' => 1,
+					'url'   => 'http://example.org',
+					'host'  => 'example.org',
+				),
+			),
+			Statify_Evaluation::get_views_for_all_referrers( '', '2023-03-23', '2023-03-24' )
+		);
+
+		self::assertSame(
+			array(
+				array(
+					'count' => 4,
+					'url'   => 'https://pluginkollektiv.de/',
+					'host'  => 'pluginkollektiv.de',
+				),
+			),
+			Statify_Evaluation::get_views_for_all_referrers( '/foo/' )
+		);
+
+		self::assertSame(
+			array(
+				array(
+					'count' => 1,
+					'url'   => 'https://example.com',
+					'host'  => 'example.com',
+				),
+			),
+			Statify_Evaluation::get_views_for_all_referrers( '/', '2023-03-20', '2023-03-23' )
+		);
+	}
+
+	/**
+	 * Test post URLs.
+	 */
+	public function test_get_post_urls() {
+		$this->insert_test_data( '2023-03-22', '', '/' );
+		$this->insert_test_data( '2023-03-23', '', '/test/', 3 );
+		$this->insert_test_data( '2023-03-24', '', '/' );
+		$this->insert_test_data( '2023-03-25', '', '/foo/', 4 );
+
+		self::assertSame(
+			array( '/', '/foo/', '/test/' ),
+			Statify_Evaluation::get_post_urls()
+		);
+	}
+}

--- a/tests/test-evaluation.php
+++ b/tests/test-evaluation.php
@@ -40,42 +40,52 @@ class Test_Evaluation extends WP_UnitTestCase {
 	 * Test views for all days.
 	 */
 	public function test_get_views_for_all_days() {
-		$this->insert_test_data( '2022-10-20', '', '/test/' );
-		$this->insert_test_data( '2023-03-23', '', '/', 3 );
-		$this->insert_test_data( '2023-03-23', '', '/test/' );
-		$this->insert_test_data( '2023-03-25', '', '/' );
-		$this->insert_test_data( '2023-03-25', '', '/test/', 2 );
+		$this->insert_test_data( '2022-12-30', '', '/test/' );
+		$this->insert_test_data( '2023-01-03', '', '/', 3 );
+		$this->insert_test_data( '2023-01-03', '', '/test/' );
+		$this->insert_test_data( '2023-01-05', '', '/' );
+		$this->insert_test_data( '2023-01-05', '', '/test/', 2 );
 
 		self::assertSame(
 			array(
-				'2022-10-20' => 1,
-				'2023-03-23' => 4,
-				'2023-03-25' => 3,
+				'2022-12-30' => 1,
+				'2022-12-31' => 0,
+				'2023-01-01' => 0,
+				'2023-01-02' => 0,
+				'2023-01-03' => 4,
+				'2023-01-04' => 0,
+				'2023-01-05' => 3,
 			),
 			Statify_Evaluation::get_views_for_all_days(),
 			'unexpected results without any filter'
 		);
 		self::assertSame(
 			array(
-				'2022-10-20' => 1,
-				'2023-03-23' => 1,
-				'2023-03-25' => 2,
+				'2022-12-30' => 1,
+				'2022-12-31' => 0,
+				'2023-01-01' => 0,
+				'2023-01-02' => 0,
+				'2023-01-03' => 1,
+				'2023-01-04' => 0,
+				'2023-01-05' => 2,
 			),
 			Statify_Evaluation::get_views_for_all_days( 0, '/test/' ),
 			'unexpected results with post filter'
 		);
 		self::assertSame(
 			array(
-				'2023-03-23' => 4,
-				'2023-03-25' => 3,
+				'2023-01-03' => 4,
+				'2023-01-04' => 0,
+				'2023-01-05' => 3,
 			),
 			Statify_Evaluation::get_views_for_all_days( 2023 ),
 			'unexpected results with year filter'
 		);
 		self::assertSame(
 			array(
-				'2023-03-23' => 1,
-				'2023-03-25' => 2,
+				'2023-01-03' => 1,
+				'2023-01-04' => 0,
+				'2023-01-05' => 2,
 			),
 			Statify_Evaluation::get_views_for_all_days( 2023, '/test/' ),
 			'unexpected results with year and post filter'

--- a/views/view-content.php
+++ b/views/view-content.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * The dashboard page.
+ *
+ * @package Statify
+ * @since   2.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+$post_types = Statify_Evaluation::get_post_types();
+if ( isset( $_GET['type'] ) && in_array( wp_unslash( $_GET['type'] ), $post_types, true ) ) {
+	$selected_type = sanitize_text_field( wp_unslash( $_GET['type'] ) );
+} else {
+	$selected_type = 'popular'; // popular = show most popular content.
+}
+
+if ( isset( $_GET['range'] ) ) {
+	$date_range = sanitize_text_field( wp_unslash( $_GET['range'] ) );
+} else {
+	$date_range = '';
+}
+if ( isset( $_GET['start'] ) ) {
+	$date_start = sanitize_text_field( wp_unslash( $_GET['start'] ) );
+} else {
+	$date_start = '';
+}
+if ( isset( $_GET['end'] ) ) {
+	$date_end = sanitize_text_field( wp_unslash( $_GET['end'] ) );
+} else {
+	$date_end = '';
+}
+
+if ( 'popular' === $selected_type ) {
+	$section_title = __( 'Most Popular Content', 'statify' );
+} else {
+	$section_title = get_post_type_object( $selected_type )->labels->name;
+}
+if ( ! empty( $date_start ) && ! empty( $date_end ) && $date_start !== $date_end ) {
+	$section_title = sprintf(
+		/* translators: 1: content type (plural), 2: start date, 3: end date */
+		__( '%1$s from %2$s to %3$s', 'statify' ),
+		$section_title,
+		Statify::parse_date( $date_start ),
+		Statify::parse_date( $date_end )
+	);
+} elseif ( ! empty( $date_start ) && $date_start === $date_end ) {
+	$section_title = sprintf(
+	/* translators: Parameters: 1: content type (plural), 2: date */
+		__( '%1$s from %2$s', 'statify' ),
+		$section_title,
+		Statify::parse_date( $date_start )
+	);
+}
+?>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Statify', 'statify' ); ?> - <?php esc_html_e( 'Content', 'statify' ); ?></h1>
+
+	<nav class="statify-dashboard-nav nav-tab-wrapper wp-clearfix" aria-label="<?php esc_attr_e( 'Popular Content and Post Types', 'statify' ); ?>">
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=statify_content' ) ); ?>"
+		   class="nav-tab<?php echo ( 'popular' === $selected_type ) ? ' nav-tab-active' : ''; ?>">
+			<?php esc_html_e( 'Most Popular Content', 'statify' ); ?>
+		</a>
+		<?php foreach ( $post_types as $pt ) : ?>
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=statify_content&type=' . $pt ) ); ?>"
+		   class="nav-tab<?php echo ( $selected_type === $pt ) ? ' nav-tab-active' : ''; ?>">
+			<?php echo esc_html( get_post_type_object( $pt )->labels->name ); ?>
+		</a>
+		<?php endforeach; ?>
+	</nav>
+
+	<form id="statify-dashboard-controls">
+		<input type="hidden" name="page" value="statify_content">
+		<?php
+		if ( 'popular' !== $selected_type ) {
+			echo '<input type="hidden" name="type" value="' . esc_attr( $selected_type ) . '">';
+		}
+		?>
+		<label for="statify-content-daterange"><?php esc_html_e( 'Date range', 'statify' ); ?></label>
+		<select id="statify-content-daterange" name="range">
+			<option value=""><?php esc_html_e( 'default (all the time)', 'statify' ); ?></option>
+			<option value="lastYear" <?php selected( $date_range, 'lastYear' ); ?>><?php esc_html_e( 'last year', 'statify' ); ?></option>
+			<option value="lastWeek" <?php selected( $date_range, 'lastWeek' ); ?>><?php esc_html_e( 'last week', 'statify' ); ?></option>
+			<option value="yesterday" <?php selected( $date_range, 'yesterday' ); ?>><?php esc_html_e( 'yesterday', 'statify' ); ?></option>
+			<option value="today" <?php selected( $date_range, 'today' ); ?>><?php esc_html_e( 'today', 'statify' ); ?></option>
+			<option value="thisWeek" <?php selected( $date_range, 'thisWeek' ); ?>><?php esc_html_e( 'this week', 'statify' ); ?></option>
+			<option value="last28days" <?php selected( $date_range, 'last28days' ); ?>><?php esc_html_e( 'last 28 days', 'statify' ); ?></option>
+			<option value="lastMonth" <?php selected( $date_range, 'lastMonth' ); ?>><?php esc_html_e( 'last month', 'statify' ); ?></option>
+			<option value="thisMonth" <?php selected( $date_range, 'thisMonth' ); ?>><?php esc_html_e( 'this month', 'statify' ); ?></option>
+			<option value="thisYear" <?php selected( $date_range, 'thisYear' ); ?>><?php esc_html_e( 'this year', 'statify' ); ?></option>
+			<option value="1stQuarter" <?php selected( $date_range, '1stQuarter' ); ?>><?php esc_html_e( '1st quarter', 'statify' ); ?></option>
+			<option value="2ndQuarter" <?php selected( $date_range, '2ndQuarter' ); ?>><?php esc_html_e( '2nd quarter', 'statify' ); ?></option>
+			<option value="3rdQuarter" <?php selected( $date_range, '3rdQuarter' ); ?>><?php esc_html_e( '3rd quarter', 'statify' ); ?></option>
+			<option value="4thQuarter" <?php selected( $date_range, '4thQuarter' ); ?>><?php esc_html_e( '4th quarter', 'statify' ); ?></option>
+			<option value="custom" <?php selected( $date_range, 'custom' ); ?>><?php esc_html_e( 'custom', 'statify' ); ?></option>
+		</select>
+		<label for="statify-content-datestart">Start date</label>
+		<input id="statify-content-datestart" name="start" type="date" value="<?php echo esc_attr( $date_start ); ?>">
+		<label for="statify-content-dateend">End date</label>
+		<input id="statify-content-dateend" name="end" type="date" value="<?php echo esc_attr( $date_end ); ?>">
+		<button type="submit" class="button-secondary"><?php esc_html_e( 'Select date period', 'statify' ); ?></button>
+	</form>
+
+	<?php if ( 'popular' === $selected_type ) : ?>
+
+	<section>
+		<h2><?php esc_html_e( 'Most Popular Content', 'statify' ); ?></h2>
+		<div class="statify-chart-container">
+			<div id="statify_chart_content" class="statify-chart">
+				<span class="spinner is-active" title="<?php esc_html_e( 'loading', 'statify' ); ?>"></span>
+			</div>
+		</div>
+	</section>
+	<?php endif; ?>
+
+	<section>
+		<h2><?php echo esc_html( $section_title ); ?></h2>
+
+		<table id="statify-table-posts" class="wp-list-table widefat striped statify-table">
+			<caption class="screen-reader-text">
+				<?php esc_html_e( 'Views per page/post', 'statify' ); ?>
+			</caption>
+			<thead>
+			<tr>
+				<th scope="col">
+					<?php
+					if ( 'popular' === $selected_type ) {
+						esc_html_e( 'Post/Page', 'statify' );
+					} else {
+						echo esc_html( get_post_type_object( $selected_type )->labels->name );
+					}
+					?>
+				</th>
+				<th scope="col"><?php esc_html_e( 'URL', 'statify' ); ?></th>
+				<?php if ( 'popular' === $selected_type ) : ?>
+				<th scope="col"><?php esc_html_e( 'Post Type', 'statify' ); ?></th>
+				<?php endif; ?>
+				<th scope="col"><?php esc_html_e( 'Views', 'statify' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Proportion', 'statify' ); ?></th>
+			</tr>
+			</thead>
+			<tbody>
+			<?php for ( $d = 1; $d <= 3; $d++ ) : ?>
+			<tr class="placeholder">
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<?php if ( 'popular' === $selected_type ) : ?>
+				<td><span>&nbsp;</span></td>
+				<?php endif; ?>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			<?php endfor; ?>
+			</tbody>
+			<tfoot>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Sum', 'statify' ); ?></th>
+				<td></td>
+				<?php if ( 'popular' === $selected_type ) : ?>
+				<td></td>
+				<?php endif; ?>
+				<td class="right"></td>
+				<td class="right"></td>
+			</tr>
+			</tfoot>
+		</table>
+	</section>
+</div>

--- a/views/view-dashboard.php
+++ b/views/view-dashboard.php
@@ -91,6 +91,7 @@ $years = Statify_Evaluation::get_years();
 	<section>
 		<h3><?php esc_html_e( 'Monthly / Yearly Views', 'statify' ); ?></h3>
 		<table id="statify-table-yearly" class="wp-list-table widefat striped statify-table">
+			<caption class="screen-reader-text"><?php esc_html_e( 'Monthly Views', 'statify' ); ?></caption>
 			<thead>
 				<tr>
 					<th scope="col"><?php esc_html_e( 'Year', 'statify' ); ?></th>
@@ -134,6 +135,15 @@ $years = Statify_Evaluation::get_years();
 			?>
 		</h3>
 		<table id="statify-table-daily" class="wp-list-table widefat striped statify-table">
+			<caption class="screen-reader-text">
+				<?php
+				printf(
+					/* translators: %s is replaced by a year number (e.g. 2023) */
+					esc_html__( 'Daily Views %s', 'statify' ),
+					esc_html( $selected_year )
+				);
+				?>
+			</caption>
 			<thead>
 			<tr>
 				<th><?php esc_html_e( 'Day', 'statify' ); ?></th>

--- a/views/view-dashboard.php
+++ b/views/view-dashboard.php
@@ -8,14 +8,67 @@
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+if ( isset( $_GET['year'] ) ) {
+	$selected_year = intval( $_GET['year'] );
+} else {
+	$selected_year = null;
+}
+$years = Statify_Evaluation::get_years();
+
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Statify', 'statify' ); ?></h1>
 
+	<nav class="statify-dashboard-nav nav-tab-wrapper wp-clearfix" aria-label="<?php esc_html_e( 'Overview and Years', 'statify' ); ?>">
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=statify_dashboard' ) ); ?>"
+		   class="nav-tab<?php echo ( empty( $selected_year ) ) ? ' nav-tab-active' : ''; ?>">
+			<?php esc_html_e( 'Overview', 'statify' ); ?>
+		</a>
+		<?php foreach ( $years as $y ) : ?>
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=statify_dashboard&year=' . $y ) ); ?>"
+		   class="nav-tab<?php echo ( $selected_year === $y ) ? ' nav-tab-active' : ''; ?>">
+			<?php echo esc_html( $y ); ?>
+		</a>
+		<?php endforeach; ?>
+	</nav>
+
 	<h2><?php esc_html_e( 'Overview', 'statify' ); ?></a></h2>
 
+	<?php if ( ! empty( $selected_year ) ) : ?>
 	<section>
-		<h3><?php esc_html_e( 'Monthly Views', 'statify' ); ?></h3>
+		<h3>
+			<?php
+			printf(
+				/* translators: %s is replaced by a year number (e.g. 2023) */
+				esc_html__( 'Daily Views %s', 'statify' ),
+				esc_html( $selected_year )
+			);
+			?>
+		</h3>
+
+		<div class="statify-chart-container">
+			<div id="statify_chart_daily" class="statify-chart" data-year="<?php echo esc_attr( $selected_year ); ?>">
+				<span class="spinner is-active" title="<?php esc_html_e( 'loading', 'statify' ); ?>"></span>
+			</div>
+		</div>
+	</section>
+	<?php endif; ?>
+
+	<section>
+		<h3>
+			<?php
+			if ( empty( $selected_year ) ) {
+				esc_html_e( 'Monthly Views', 'statify' );
+			} else {
+				printf(
+					/* translators: %s is replaced by a year number (e.g. 2023) */
+					esc_html__( 'Monthly Views %s', 'statify' ),
+					esc_html( $selected_year )
+				);
+			}
+			?>
+		</h3>
 
 		<div class="statify-chart-container">
 			<div id="statify_chart_monthly" class="statify-chart">
@@ -24,6 +77,7 @@ defined( 'ABSPATH' ) || exit;
 		</div>
 	</section>
 
+	<?php if ( empty( $selected_year ) ) : ?>
 	<section>
 		<h3><?php esc_html_e( 'Yearly Views', 'statify' ); ?></h3>
 
@@ -61,9 +115,113 @@ defined( 'ABSPATH' ) || exit;
 					<td><span>&nbsp;</span></td>
 					<td><span>&nbsp;</span></td>
 					<td><span>&nbsp;</span></td>
-					<td><span>&nbsp;</span></td>
+					<td class="statify-table-sum"><span>&nbsp;</span></td>
 				</tr>
 			</tbody>
 		</table>
 	</section>
+
+	<?php else : ?>
+
+	<section>
+		<h3>
+			<?php
+			printf(
+				/* translators: %s is replaced by a year number (e.g. 2023) */
+				esc_html__( 'Daily Views %s', 'statify' ),
+				esc_html( $selected_year )
+			);
+			?>
+		</h3>
+		<table id="statify-table-daily" class="wp-list-table widefat striped statify-table">
+			<thead>
+			<tr>
+				<th><?php esc_html_e( 'Day', 'statify' ); ?></th>
+				<?php for ( $mon = 1; $mon <= 12; $mon++ ) : ?>
+					<th scope="col"><?php echo esc_html( date_i18n( 'M', strtotime( '0000-' . $mon . '-01' ) ) ); ?></th>
+				<?php endfor; ?>
+			</tr>
+			</thead>
+			<tbody>
+			<?php for ( $d = 1; $d <= 31; $d++ ) : ?>
+			<tr class="placeholder">
+				<th scope="col"><?php echo esc_html( $d ); ?></th>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			<?php endfor; ?>
+			<tr class="placeholder statify-table-sum">
+				<th scope="col"><?php esc_html_e( 'Sum', 'statify' ); ?></th>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			<tr class="placeholder statify-table-avg">
+				<th scope="col"><?php esc_html_e( 'Average', 'statify' ); ?></th>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			<tr class="placeholder statify-table-min">
+				<th scope="col"><?php esc_html_e( 'Minimum', 'statify' ); ?></th>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			<tr class="placeholder statify-table-max">
+				<th scope="col"><?php esc_html_e( 'Maximum', 'statify' ); ?></th>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+	<?php endif; ?>
 </div>

--- a/views/view-dashboard.php
+++ b/views/view-dashboard.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * The dashboard page.
+ *
+ * @package Statify
+ * @since   2.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+?>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Statify', 'statify' ); ?></h1>
+
+	<h2><?php esc_html_e( 'Overview', 'statify' ); ?></a></h2>
+
+	<section>
+		<h3><?php esc_html_e( 'Monthly Views', 'statify' ); ?></h3>
+
+		<div class="statify-chart-container">
+			<div id="statify_chart_monthly" class="statify-chart">
+				<span class="spinner is-active" title="<?php esc_html_e( 'loading', 'statify' ); ?>"></span>
+			</div>
+		</div>
+	</section>
+
+	<section>
+		<h3><?php esc_html_e( 'Yearly Views', 'statify' ); ?></h3>
+
+		<div class="statify-chart-container">
+			<div id="statify_chart_yearly" class="statify-chart">
+				<span class="spinner is-active" title="<?php esc_html_e( 'loading', 'statify' ); ?>"></span>
+			</div>
+		</div>
+	</section>
+
+	<section>
+		<h3><?php esc_html_e( 'Monthly / Yearly Views', 'statify' ); ?></h3>
+		<table id="statify-table-yearly" class="wp-list-table widefat striped statify-table">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Year', 'statify' ); ?></th>
+					<?php for ( $mon = 1; $mon <= 12; $mon++ ) : ?>
+					<th scope="col"><?php echo esc_html( date_i18n( 'M', strtotime( '1970-' . $mon . '-01' ) ) ); ?></th>
+					<?php endfor; ?>
+					<th scope="col" class="right sum"><?php esc_html_e( 'Sum', 'statify' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr class="placeholder">
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+					<td><span>&nbsp;</span></td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+</div>

--- a/views/view-dashboard.php
+++ b/views/view-dashboard.php
@@ -16,6 +16,12 @@ if ( isset( $_GET['year'] ) ) {
 }
 $years = Statify_Evaluation::get_years();
 
+if ( isset( $_GET['post'] ) ) {
+	$selected_post = sanitize_text_field( wp_unslash( $_GET['post'] ) );
+} else {
+	$selected_post = null;
+}
+
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Statify', 'statify' ); ?></h1>
@@ -34,6 +40,21 @@ $years = Statify_Evaluation::get_years();
 	</nav>
 
 	<h2><?php esc_html_e( 'Overview', 'statify' ); ?></a></h2>
+
+	<form id="statify-dashboard-controls">
+		<input type="hidden" name="page" value="statify_dashboard">
+		<?php
+		if ( ! empty( $selected_year ) ) {
+			echo '<input type="hidden" name="year" value="' . esc_attr( $selected_year ) . '">';
+		}
+		?>
+		<label for="statify-dashboard-post"><?php esc_html_e( 'Post/Page', 'statify' ); ?></label>
+		<input id="statify-dashboard-post" name="post" type="text" list="statify-dashboard-posts" value="<?php echo esc_attr( $selected_post ); ?>">
+		<datalist id="statify-dashboard-posts">
+			<option value=""></option>
+		</datalist>
+		<button type="submit" class="button-secondary"><?php esc_html_e( 'Select post/page', 'statify' ); ?></button>
+	</form>
 
 	<?php if ( ! empty( $selected_year ) ) : ?>
 	<section>

--- a/views/view-referrers.php
+++ b/views/view-referrers.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * The dashboard page.
+ *
+ * @package Statify
+ * @since   2.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+if ( isset( $_GET['range'] ) ) {
+	$date_range = sanitize_text_field( wp_unslash( $_GET['range'] ) );
+} else {
+	$date_range = '';
+}
+if ( isset( $_GET['start'] ) ) {
+	$date_start = sanitize_text_field( wp_unslash( $_GET['start'] ) );
+} else {
+	$date_start = '';
+}
+if ( isset( $_GET['end'] ) ) {
+	$date_end = sanitize_text_field( wp_unslash( $_GET['end'] ) );
+} else {
+	$date_end = '';
+}
+if ( isset( $_GET['post'] ) ) {
+	$selected_post = sanitize_text_field( wp_unslash( $_GET['post'] ) );
+} else {
+	$selected_post = '';
+}
+
+$selected_post_title = Statify_Evaluation::post_title( $selected_post );
+if ( ! empty( $date_start ) && ! empty( $date_end ) && $date_start !== $date_end ) {
+	$section_title = sprintf(
+		/* translators: 1: start date, 2: end date, 3: post title or "all posts" */
+		__( 'Referrers from other websites from %1$s to %3$s for %3$s', 'statify' ),
+		Statify::parse_date( $date_start ),
+		Statify::parse_date( $date_end ),
+		$selected_post_title
+	);
+} elseif ( ! empty( $date_start ) && $date_start === $date_end ) {
+	$section_title = sprintf(
+		/* translators: 1: date, 2: post title or "all posts" */
+		__( 'Referrers from other websites from %1$s for %2$s', 'statify' ),
+		Statify::parse_date( $date_start ),
+		$selected_post_title
+	);
+} else {
+	$section_title = sprintf(
+		/* translators: %s is replaced by a post title or "all posts" */
+		__( 'Referrers from other websites for %s', 'statify' ),
+		$selected_post_title
+	);
+}
+?>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Statify', 'statify' ); ?> - <?php esc_html_e( 'Referrers from other websites', 'statify' ); ?></h1>
+
+	<form id="statify-dashboard-controls">
+		<input type="hidden" name="page" value="statify_referrers">
+		<label for="statify-content-daterange"><?php esc_html_e( 'Date range', 'statify' ); ?></label>
+		<select id="statify-content-daterange" name="range">
+			<option value=""><?php esc_html_e( 'default (all the time)', 'statify' ); ?></option>
+			<option value="lastYear" <?php selected( $date_range, 'lastYear' ); ?>><?php esc_html_e( 'last year', 'statify' ); ?></option>
+			<option value="lastWeek" <?php selected( $date_range, 'lastWeek' ); ?>><?php esc_html_e( 'last week', 'statify' ); ?></option>
+			<option value="yesterday" <?php selected( $date_range, 'yesterday' ); ?>><?php esc_html_e( 'yesterday', 'statify' ); ?></option>
+			<option value="today" <?php selected( $date_range, 'today' ); ?>><?php esc_html_e( 'today', 'statify' ); ?></option>
+			<option value="thisWeek" <?php selected( $date_range, 'thisWeek' ); ?>><?php esc_html_e( 'this week', 'statify' ); ?></option>
+			<option value="last28days" <?php selected( $date_range, 'last28days' ); ?>><?php esc_html_e( 'last 28 days', 'statify' ); ?></option>
+			<option value="lastMonth" <?php selected( $date_range, 'lastMonth' ); ?>><?php esc_html_e( 'last month', 'statify' ); ?></option>
+			<option value="thisMonth" <?php selected( $date_range, 'thisMonth' ); ?>><?php esc_html_e( 'this month', 'statify' ); ?></option>
+			<option value="thisYear" <?php selected( $date_range, 'thisYear' ); ?>><?php esc_html_e( 'this year', 'statify' ); ?></option>
+			<option value="1stQuarter" <?php selected( $date_range, '1stQuarter' ); ?>><?php esc_html_e( '1st quarter', 'statify' ); ?></option>
+			<option value="2ndQuarter" <?php selected( $date_range, '2ndQuarter' ); ?>><?php esc_html_e( '2nd quarter', 'statify' ); ?></option>
+			<option value="3rdQuarter" <?php selected( $date_range, '3rdQuarter' ); ?>><?php esc_html_e( '3rd quarter', 'statify' ); ?></option>
+			<option value="4thQuarter" <?php selected( $date_range, '4thQuarter' ); ?>><?php esc_html_e( '4th quarter', 'statify' ); ?></option>
+			<option value="custom" <?php selected( $date_range, 'custom' ); ?>><?php esc_html_e( 'custom', 'statify' ); ?></option>
+		</select>
+		<label for="statify-content-datestart">Start date</label>
+		<input id="statify-content-datestart" name="start" type="date" value="<?php echo esc_attr( $date_start ); ?>">
+		<label for="statify-content-dateend">End date</label>
+		<input id="statify-content-dateend" name="end" type="date" value="<?php echo esc_attr( $date_end ); ?>">
+		<button type="submit" class="button-secondary"><?php esc_html_e( 'Select date period', 'statify' ); ?></button>
+
+		<br>
+
+		<label for="statify-dashboard-post"><?php esc_html_e( 'Post/Page', 'statify' ); ?></label>
+		<input id="statify-dashboard-post" name="post" type="text" list="statify-dashboard-posts" value="<?php echo esc_attr( $selected_post ); ?>">
+		<datalist id="statify-dashboard-posts">
+			<option value=""></option>
+		</datalist>
+		<button type="submit" class="button-secondary"><?php esc_html_e( 'Select post/page', 'statify' ); ?></button>
+	</form>
+
+	<section>
+		<div class="statify-chart-container">
+			<div id="statify_chart_referrer" class="statify-chart">
+				<span class="spinner is-active" title="<?php esc_html_e( 'loading', 'statify' ); ?>"></span>
+			</div>
+		</div>
+	</section>
+
+	<section>
+		<h2><?php echo esc_html( $section_title ); ?></h2>
+
+		<table id="statify-table-referrer" class="wp-list-table widefat striped statify-table">
+			<caption class="screen-reader-text">
+				<?php esc_html_e( 'Views per referrer', 'statify' ); ?>
+			</caption>
+			<thead>
+			<tr>
+				<th scope="col"><?php esc_html_e( 'Referring Domain', 'statify' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Views', 'statify' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Proportion', 'statify' ); ?></th>
+			</tr>
+			</thead>
+			<tbody>
+			<?php for ( $d = 1; $d <= 3; $d++ ) : ?>
+			<tr class="placeholder">
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+				<td><span>&nbsp;</span></td>
+			</tr>
+			<?php endfor; ?>
+			</tbody>
+			<tfoot>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Sum', 'statify' ); ?></th>
+				<td class="right"></td>
+				<td class="right"></td>
+			</tr>
+			</tfoot>
+		</table>
+	</section>
+</div>

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -14,7 +14,7 @@ $limit       = (int) Statify::$_options['limit'];
 $show_totals = (int) Statify::$_options['show_totals'];
 ?>
 
-	<div id="statify_chart">
+	<div id="statify_chart" class="statify-chart">
 		<span class="spinner is-active" title="<?php esc_html_e( 'loading', 'statify' ); ?>"></span>
 	</div>
 


### PR DESCRIPTION
Integrate dashboards from _Extended Evaluation for Statify_ by @patrickrobrecht 
(https://github.com/patrickrobrecht/extended-evaluation-for-statify) 

We include the queries without any semantic change and introduce 3 new admin pages.
Rendering of charts and tables is done client-side, as we now do for the small dashboard widget, too and all data is retrieved via WP API.

**This is Work in Progress**

* Backend/API:
  * [x] Yearly/monthly values
  * [x] Daily values
  * [x] Filter by post/page
  * [x] Top targets
  * [x] Top referrers
* UI:
  * [x] Yearly/monthly overview
  * [x] Per-year tabs with monthly/daily values
  * [x] Filter by post/page
  * [x] Top targets
  * [x] Top referrers
  * [x] CSV export

**SNAPSHOT Builds:**

* ~statify.2.0.0-snap257-20250824.zip~
* ~statify.2.0.0-snap257-20250826.zip~
* ~[statify.2.0.0-snap257-20250828.zip](https://github.com/user-attachments/files/22019734/statify.2.0.0-snap257-20250828.zip)~
* [statify.2.0.0-snap257-20260315.zip](https://github.com/user-attachments/files/26005508/statify.2.0.0-snap257-20260315.zip)



(use at own risk)

----
<img width="686" height="1004" alt="statfy257_001" src="https://github.com/user-attachments/assets/36522d03-1b1c-4980-91ff-b1f6d0add2fc" />
<img width="686" height="1004" alt="statfy257_002" src="https://github.com/user-attachments/assets/4ab1a1c8-e354-4d36-a23a-ed6d8927a02d" />

<img width="696" height="782" alt="statfy257_003" src="https://github.com/user-attachments/assets/4575ea21-49e1-4f66-a5f5-750e8317ecc5" />

