### PR TITLE
copy third-party libs instead of using Composer autoloader (#256)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage
 css/*.min.css
 js/*.min.js
 js/*.min.js.map
+lib
 phpunit.*.xml
 vendor/
 node_modules/

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
   },
   "extra": {
     "copy-file": {
+      "vendor/jaybizzle/crawler-detect/src/": "lib/Jaybizzle/CrawlerDetect/",
       "vendor/npm-asset/chartist/dist/index.css": "css/chartist.min.css",
       "vendor/npm-asset/chartist/dist/index.umd.js": "js/chartist.min.js",
       "vendor/npm-asset/chartist-plugin-tooltips-updated/dist/chartist-plugin-tooltip.min.js": "js/"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,9 +19,6 @@
     <file>statify.php</file>
     <exclude-pattern>vendor/*</exclude-pattern>
 
-    <!-- Exclude minified Javascript files. -->
-    <exclude-pattern>*.min.js</exclude-pattern>
-
     <!-- WordPress coding standards -->
     <config name="minimum_supported_wp_version" value="4.7" />
     <rule ref="WordPress">

--- a/statify.php
+++ b/statify.php
@@ -53,9 +53,6 @@ register_uninstall_hook(
 	)
 );
 
-/* Composer Autoload */
-require __DIR__ . '/vendor/autoload.php';
-
 /* Autoload */
 spl_autoload_register( 'statify_autoload' );
 
@@ -86,6 +83,12 @@ function statify_autoload( $class ) {
 			'%s/inc/class-%s.php',
 			STATIFY_DIR,
 			strtolower( str_replace( '_', '-', $class ) )
+		);
+	} elseif ( 0 === strncmp( $class, 'Jaybizzle\\CrawlerDetect\\', 24 ) && ! class_exists( $class, false ) ) {
+		require_once sprintf(
+			'%s/lib/%s.php',
+			STATIFY_DIR,
+			str_replace( '\\', DIRECTORY_SEPARATOR, $class )
 		);
 	}
 }


### PR DESCRIPTION
fixes #256 

The  autoloader mechanism is quite heavy for a single dependency and requires _composer_ and _vendor_ dir to be part of the final product.

We yet have generated/minified resources in our project, so this is the minimalistic approach to copy the _CrawlerDetect_ lib, too and extend the custom autoloader mechanism.

----

This is not a pretty solution, but the project is not really _Composer_ compatible. (no PSR-4 namespaces, requirement for minified files that are generated from dev-dependencies, etc.).

This way we ca postpone the decision to heavily rework the project structures while having a runnable artifact again.