### PR TITLE
migrate to PSR-4 namespace and use Composer in production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,11 @@
       "vendor/npm-asset/chartist-plugin-tooltips-updated/dist/chartist-plugin-tooltip.min.js": "js/"
     }
   },
+  "autoload": {
+    "psr-4": {
+      "Statify\\": "inc/"
+    }
+  },
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Statify\\": "inc/"
+      "Pluginkollektiv\\Statify\\": "inc/"
     }
   },
   "config": {

--- a/inc/Api.php
+++ b/inc/Api.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_API class
+ * Statify: API class
  *
  * This file contains methods for REST API integration.
  *
@@ -8,15 +8,20 @@
  * @since   1.9
  */
 
+namespace Statify;
+
+use WP_REST_Response;
+use WP_REST_Server;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Statify REST API integration.
  *
- * @since 1.9
+ * @since 2.0.0
  */
-class Statify_Api extends Statify {
+class Api extends Statify {
 	/**
 	 * REST endpoints
 	 *
@@ -122,7 +127,7 @@ class Statify_Api extends Statify {
 	public static function get_stats( $request ) {
 		$refresh = '1' === $request->get_param( 'refresh' );
 
-		$stats  = Statify_Dashboard::get_stats( $refresh );
+		$stats  = Dashboard::get_stats( $refresh );
 
 		$visits          = $stats['visits'];
 		$stats['visits'] = array();

--- a/inc/Api.php
+++ b/inc/Api.php
@@ -8,7 +8,7 @@
  * @since   1.9
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use WP_REST_Response;
 use WP_REST_Server;

--- a/inc/Backend.php
+++ b/inc/Backend.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Backend class
+ * Statify: Backend class
  *
  * This file contains the derived class for the plugin's backend features.
  *
@@ -8,15 +8,18 @@
  * @since     1.4.0
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Backend
+ * Statify Backend
  *
  * @since 1.4.0
+ * @since 2.0.0 renamed to Statify\Backend
  */
-class Statify_Backend {
+class Backend {
 
 	/**
 	 * Add plugin meta links

--- a/inc/Backend.php
+++ b/inc/Backend.php
@@ -8,7 +8,7 @@
  * @since     1.4.0
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Backend
  *
  * @since 1.4.0
- * @since 2.0.0 renamed to Statify\Backend
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Backend
  */
 class Backend {
 

--- a/inc/Cron.php
+++ b/inc/Cron.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Cron class
+ * Statify: Cron class
  *
  * This file contains the derived class for the plugin's cron features.
  *
@@ -8,15 +8,18 @@
  * @since     1.4.0
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Cron
+ * Statify Cron
  *
  * @since 1.4.0
+ * @since 2.0.0 renamed to Statify\Cron
  */
-class Statify_Cron extends Statify {
+class Cron extends Statify {
 
 	/**
 	 * Cleanup obsolete DB values

--- a/inc/Cron.php
+++ b/inc/Cron.php
@@ -8,7 +8,7 @@
  * @since     1.4.0
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Cron
  *
  * @since 1.4.0
- * @since 2.0.0 renamed to Statify\Cron
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Cron
  */
 class Cron extends Statify {
 

--- a/inc/Dashboard.php
+++ b/inc/Dashboard.php
@@ -8,7 +8,7 @@
  * @since     1.1
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Dashboard
  *
  * @since 1.1
- * @since 2.0.0 renamed to Statify\Dashboard
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Dashboard
  */
 class Dashboard extends Statify {
 

--- a/inc/Dashboard.php
+++ b/inc/Dashboard.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Dashboard class
+ * Statify: Dashboard class
  *
  * This file contains the derived class for the plugin's dashboard features.
  *
@@ -8,15 +8,18 @@
  * @since     1.1
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Dashboard
+ * Statify Dashboard
  *
  * @since 1.1
+ * @since 2.0.0 renamed to Statify\Dashboard
  */
-class Statify_Dashboard extends Statify {
+class Dashboard extends Statify {
 
 	/**
 	 * Plugin version.

--- a/inc/Deactivate.php
+++ b/inc/Deactivate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Deactivate class
+ * Statify: Deactivate class
  *
  * This file contains the derived class for the plugin's deactivation actions.
  *
@@ -8,15 +8,18 @@
  * @since     1.4.0
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Deactivate
+ * Statify Deactivate
  *
  * @since 1.4.0
+ * @since 2.0.0 renamed to Statify\Deactivate
  */
-class Statify_Deactivate {
+class Deactivate {
 
 	/**
 	 * Plugin deactivation actions

--- a/inc/Deactivate.php
+++ b/inc/Deactivate.php
@@ -8,7 +8,7 @@
  * @since     1.4.0
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Deactivate
  *
  * @since 1.4.0
- * @since 2.0.0 renamed to Statify\Deactivate
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Deactivate
  */
 class Deactivate {
 

--- a/inc/Frontend.php
+++ b/inc/Frontend.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Frontend class
+ * Statify: Frontend class
  *
  * This file contains the derived class for the plugin's frontend features.
  *
@@ -8,15 +8,18 @@
  * @since     1.4.0
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Frontend
+ * Statify Frontend
  *
  * @since 1.4.0
+ * @since 2.0.0 renamed to Statify\Frontend
  */
-class Statify_Frontend extends Statify {
+class Frontend extends Statify {
 
 	/**
 	 * Track the page view
@@ -96,7 +99,7 @@ class Statify_Frontend extends Statify {
 
 		// Add endpoint to script.
 		$script_data = array(
-			'url' => esc_url_raw( rest_url( Statify_Api::REST_NAMESPACE . '/' . Statify_Api::REST_ROUTE_TRACK ) ),
+			'url' => esc_url_raw( rest_url( Api::REST_NAMESPACE . '/' . Api::REST_ROUTE_TRACK ) ),
 		);
 		if ( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK === self::$_options['snippet'] ) {
 			$script_data['nonce'] = wp_create_nonce( 'statify_track' );
@@ -159,7 +162,7 @@ class Statify_Frontend extends Statify {
 	private static function make_amp_config() {
 		$cfg = array(
 			'requests'       => array(
-				'pageview' => rest_url( Statify_Api::REST_NAMESPACE . '/' . Statify_Api::REST_ROUTE_TRACK ),
+				'pageview' => rest_url( Api::REST_NAMESPACE . '/' . Api::REST_ROUTE_TRACK ),
 			),
 			'extraUrlParams' => array(
 				'referrer' => '${documentReferrer}',

--- a/inc/Frontend.php
+++ b/inc/Frontend.php
@@ -8,7 +8,7 @@
  * @since     1.4.0
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Frontend
  *
  * @since 1.4.0
- * @since 2.0.0 renamed to Statify\Frontend
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Frontend
  */
 class Frontend extends Statify {
 

--- a/inc/Install.php
+++ b/inc/Install.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Install class
+ * Statify: Install class
  *
  * This file contains the derived class for the plugin's installation features.
  *
@@ -8,16 +8,18 @@
  * @since     0.1
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Install
+ * Statify Install
  *
- * @since   0.1
- * @version 2016-12-20
+ * @since 0.1
+ * @since 2.0.0 renamed to Statify\Install
  */
-class Statify_Install {
+class Install {
 
 	/**
 	 * Plugin activation handler.
@@ -83,7 +85,7 @@ class Statify_Install {
 		}
 
 		// Create the actual tables.
-		Statify_Table::init();
-		Statify_Table::create();
+		Table::init();
+		Table::create();
 	}
 }

--- a/inc/Install.php
+++ b/inc/Install.php
@@ -8,7 +8,7 @@
  * @since     0.1
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Install
  *
  * @since 0.1
- * @since 2.0.0 renamed to Statify\Install
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Install
  */
 class Install {
 

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -8,7 +8,7 @@
  * @since     1.7
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed directly..
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Settings
  *
  * @since 1.7
- * @since 2.0.0 renamed to Statify\Settings
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Settings
  */
 class Settings {
 

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Settings class
+ * Statify: Settings class
  *
  * This file contains the plugin's settings capabilities.
  *
@@ -8,15 +8,18 @@
  * @since     1.7
  */
 
+namespace Statify;
+
 // Quit if accessed directly..
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class Statify_Settings
+ * Statify Settings
  *
  * @since 1.7
+ * @since 2.0.0 renamed to Statify\Settings
  */
-class Statify_Settings {
+class Settings {
 
 	/**
 	 * Registers all options using the WP Settings API.

--- a/inc/Statify.php
+++ b/inc/Statify.php
@@ -8,6 +8,8 @@
  * @since     0.1.0
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
@@ -15,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify.
  *
  * @since 0.1.0
+ * @since 2.0.0 moved to Statify namespace
  */
 class Statify {
 	const TRACKING_METHOD_DEFAULT = 0;
@@ -41,7 +44,7 @@ class Statify {
 		}
 
 		// Table init.
-		Statify_Table::init();
+		Table::init();
 
 		// Plugin options.
 		self::$_options = wp_parse_args(
@@ -62,31 +65,31 @@ class Statify {
 		);
 
 		// Cron.
-		add_action( 'statify_cleanup', array( 'Statify_Cron', 'cleanup_data' ) );
+		add_action( 'statify_cleanup', array( 'Statify\Cron', 'cleanup_data' ) );
 
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {  // XMLRPC.
-			add_filter( 'xmlrpc_methods', array( 'Statify_XMLRPC', 'xmlrpc_methods' ) );
+			add_filter( 'xmlrpc_methods', array( 'Statify\XMLRPC', 'xmlrpc_methods' ) );
 		} elseif ( is_admin() ) {   // Backend.
-			add_action( 'wp_initialize_site', array( 'Statify_Install', 'init_site' ) );
-			add_action( 'wp_uninitialize_site', array( 'Statify_Uninstall', 'init_site' ) );
-			add_action( 'wp_dashboard_setup', array( 'Statify_Dashboard', 'init' ) );
-			add_filter( 'plugin_row_meta', array( 'Statify_Backend', 'add_meta_link' ), 10, 2 );
-			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify_Backend', 'add_action_link' ) );
-			add_action( 'admin_init', array( 'Statify_Settings', 'register_settings' ) );
-			add_action( 'admin_menu', array( 'Statify_Settings', 'add_admin_menu' ) );
-			add_action( 'update_option_statify', array( 'Statify_Settings', 'action_update_options' ), 10, 2 );
+			add_action( 'wp_initialize_site', array( 'Statify\Install', 'init_site' ) );
+			add_action( 'wp_uninitialize_site', array( 'Statify\Uninstall', 'init_site' ) );
+			add_action( 'wp_dashboard_setup', array( 'Statify\Dashboard', 'init' ) );
+			add_filter( 'plugin_row_meta', array( 'Statify\Backend', 'add_meta_link' ), 10, 2 );
+			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify\Backend', 'add_action_link' ) );
+			add_action( 'admin_init', array( 'Statify\Settings', 'register_settings' ) );
+			add_action( 'admin_menu', array( 'Statify\Settings', 'add_admin_menu' ) );
+			add_action( 'update_option_statify', array( 'Statify\Settings', 'action_update_options' ), 10, 2 );
 		} else {    // Frontend.
-			add_action( 'template_redirect', array( 'Statify_Frontend', 'track_visit' ) );
-			add_filter( 'query_vars', array( 'Statify_Frontend', 'query_vars' ) );
-			add_action( 'wp_footer', array( 'Statify_Frontend', 'wp_footer' ) );
+			add_action( 'template_redirect', array( 'Statify\Frontend', 'track_visit' ) );
+			add_filter( 'query_vars', array( 'Statify\Frontend', 'query_vars' ) );
+			add_action( 'wp_footer', array( 'Statify\Frontend', 'wp_footer' ) );
 			if ( function_exists( 'amp_is_request' ) || function_exists( 'is_amp_endpoint' ) ) {
 				// Automattic AMP plugin present.
-				add_filter( 'amp_analytics_entries', array( 'Statify_Frontend', 'amp_analytics_entries' ) );
-				add_filter( 'amp_post_template_analytics', array( 'Statify_Frontend', 'amp_post_template_analytics' ) );
+				add_filter( 'amp_analytics_entries', array( 'Statify\Frontend', 'amp_analytics_entries' ) );
+				add_filter( 'amp_post_template_analytics', array( 'Statify\Frontend', 'amp_post_template_analytics' ) );
 			}
 			// Initialize REST API.
 			if ( self::is_javascript_tracking_enabled() ) {
-				add_filter( 'rest_api_init', array( 'Statify_Api', 'init' ) );
+				add_filter( 'rest_api_init', array( 'Statify\Api', 'init' ) );
 			}
 		}
 	}
@@ -101,7 +104,7 @@ class Statify {
 	 *
 	 * @since  0.1.0
 	 * @since  1.7.0 $is_snippet parameter added.
-	 * @since  2.0.0 Migration from Statify_Frontend::track_visit to Statify::track with multiple parameters.
+	 * @since  2.0.0 Migration from Frontend::track_visit to Statify::track with multiple parameters.
 	 */
 	protected static function track( $referrer, $target ) {
 		// Fallbacks for uninitialized or omitted target and referrer values.
@@ -234,7 +237,7 @@ class Statify {
 	 * @return boolean $skip_hook TRUE if NO tracking is desired.
 	 *
 	 * @since  1.2.6
-	 * @since  2.0.0 Migration from Statify_Frontend to Statify class.
+	 * @since  2.0.0 Migration from Frontend to Statify class.
 	 */
 	private static function skip_tracking() {
 		if ( function_exists( 'apply_filters_deprecated' ) ) {
@@ -279,7 +282,7 @@ class Statify {
 	 * @return boolean $is_bot TRUE if user agent is a bot, FALSE if not.
 	 *
 	 * @since 1.7.0
-	 * @since 2.0.0 Migration from Statify_Frontend to Statify class, removed $user_agent parameter.
+	 * @since 2.0.0 Migration from Frontend to Statify class, removed $user_agent parameter.
 	 */
 	private static function is_bot() {
 		$crawler_detect = new \Jaybizzle\CrawlerDetect\CrawlerDetect();
@@ -294,7 +297,7 @@ class Statify {
 	 * @return boolean  $skip_hook TRUE if NO tracking is desired
 	 *
 	 * @since 1.6.1
-	 * @since 1.9.0 Migration from Statify_Frontend to Statify class.
+	 * @since 1.9.0 Migration from Frontend to Statify class.
 	 */
 	protected static function is_internal() {
 		// Skip for preview, 404 calls, feed, search, favicon and sitemap access.
@@ -310,7 +313,7 @@ class Statify {
 	 * @return  boolean TRUE of referrer matches disallowed keys entry and should thus be excluded.
 	 *
 	 * @since 1.5.0
-	 * @since 1.9.0 Migration from Statify_Frontend to Statify class.
+	 * @since 1.9.0 Migration from Frontend to Statify class.
 	 */
 	private static function check_referrer() {
 		// Return false if the disallowed-keys filter (formerly blacklist) is inactive.
@@ -353,7 +356,7 @@ class Statify {
 	 * @return array
 	 *
 	 * @since 1.7.3 Renamed to "get_disallowed_keys" to match WP 5.5. wording.
-	 * @since 1.9.0 Migration from Statify_Frontend to Statify class.
+	 * @since 1.9.0 Migration from Frontend to Statify class.
 	 */
 	private static function get_disallowed_keys() {
 		$disallowed_keys = get_option( 'disallowed_keys' );

--- a/inc/Statify.php
+++ b/inc/Statify.php
@@ -8,7 +8,7 @@
  * @since     0.1.0
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify.
  *
  * @since 0.1.0
- * @since 2.0.0 moved to Statify namespace
+ * @since 2.0.0 moved to Pluginkollektiv\Statify namespace
  */
 class Statify {
 	const TRACKING_METHOD_DEFAULT = 0;
@@ -65,31 +65,31 @@ class Statify {
 		);
 
 		// Cron.
-		add_action( 'statify_cleanup', array( 'Statify\Cron', 'cleanup_data' ) );
+		add_action( 'statify_cleanup', array( 'Pluginkollektiv\\Statify\Cron', 'cleanup_data' ) );
 
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {  // XMLRPC.
-			add_filter( 'xmlrpc_methods', array( 'Statify\XMLRPC', 'xmlrpc_methods' ) );
+			add_filter( 'xmlrpc_methods', array( 'Pluginkollektiv\\Statify\Xmlrpc', 'xmlrpc_methods' ) );
 		} elseif ( is_admin() ) {   // Backend.
-			add_action( 'wp_initialize_site', array( 'Statify\Install', 'init_site' ) );
-			add_action( 'wp_uninitialize_site', array( 'Statify\Uninstall', 'init_site' ) );
-			add_action( 'wp_dashboard_setup', array( 'Statify\Dashboard', 'init' ) );
-			add_filter( 'plugin_row_meta', array( 'Statify\Backend', 'add_meta_link' ), 10, 2 );
-			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify\Backend', 'add_action_link' ) );
-			add_action( 'admin_init', array( 'Statify\Settings', 'register_settings' ) );
-			add_action( 'admin_menu', array( 'Statify\Settings', 'add_admin_menu' ) );
-			add_action( 'update_option_statify', array( 'Statify\Settings', 'action_update_options' ), 10, 2 );
+			add_action( 'wp_initialize_site', array( 'Pluginkollektiv\\Statify\Install', 'init_site' ) );
+			add_action( 'wp_uninitialize_site', array( 'Pluginkollektiv\\Statify\Uninstall', 'init_site' ) );
+			add_action( 'wp_dashboard_setup', array( 'Pluginkollektiv\\Statify\Dashboard', 'init' ) );
+			add_filter( 'plugin_row_meta', array( 'Pluginkollektiv\\Statify\Backend', 'add_meta_link' ), 10, 2 );
+			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Pluginkollektiv\\Statify\Backend', 'add_action_link' ) );
+			add_action( 'admin_init', array( 'Pluginkollektiv\\Statify\Settings', 'register_settings' ) );
+			add_action( 'admin_menu', array( 'Pluginkollektiv\\Statify\Settings', 'add_admin_menu' ) );
+			add_action( 'update_option_statify', array( 'Pluginkollektiv\\Statify\Settings', 'action_update_options' ), 10, 2 );
 		} else {    // Frontend.
-			add_action( 'template_redirect', array( 'Statify\Frontend', 'track_visit' ) );
-			add_filter( 'query_vars', array( 'Statify\Frontend', 'query_vars' ) );
-			add_action( 'wp_footer', array( 'Statify\Frontend', 'wp_footer' ) );
+			add_action( 'template_redirect', array( 'Pluginkollektiv\\Statify\Frontend', 'track_visit' ) );
+			add_filter( 'query_vars', array( 'Pluginkollektiv\\Statify\Frontend', 'query_vars' ) );
+			add_action( 'wp_footer', array( 'Pluginkollektiv\\Statify\Frontend', 'wp_footer' ) );
 			if ( function_exists( 'amp_is_request' ) || function_exists( 'is_amp_endpoint' ) ) {
 				// Automattic AMP plugin present.
-				add_filter( 'amp_analytics_entries', array( 'Statify\Frontend', 'amp_analytics_entries' ) );
-				add_filter( 'amp_post_template_analytics', array( 'Statify\Frontend', 'amp_post_template_analytics' ) );
+				add_filter( 'amp_analytics_entries', array( 'Pluginkollektiv\\Statify\Frontend', 'amp_analytics_entries' ) );
+				add_filter( 'amp_post_template_analytics', array( 'Pluginkollektiv\\Statify\Frontend', 'amp_post_template_analytics' ) );
 			}
 			// Initialize REST API.
 			if ( self::is_javascript_tracking_enabled() ) {
-				add_filter( 'rest_api_init', array( 'Statify\Api', 'init' ) );
+				add_filter( 'rest_api_init', array( 'Pluginkollektiv\\Statify\Api', 'init' ) );
 			}
 		}
 	}

--- a/inc/Table.php
+++ b/inc/Table.php
@@ -8,7 +8,7 @@
  * @since     0.6
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Table
  *
  * @since 0.6
- * @since 2.0.0 renamed to Statify\Table
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Table
  */
 class Table {
 

--- a/inc/Table.php
+++ b/inc/Table.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Statify: Statify_Table class
+ * Statify: Table class
  *
  * This file contains class for the plugin's DB table handling.
  *
  * @package   Statify
  * @since     0.6
  */
+
+namespace Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -15,8 +17,9 @@ defined( 'ABSPATH' ) || exit;
  * Statify Table
  *
  * @since 0.6
+ * @since 2.0.0 renamed to Statify\Table
  */
-class Statify_Table {
+class Table {
 
 	/**
 	 * Definition of the custom table.

--- a/inc/Uninstall.php
+++ b/inc/Uninstall.php
@@ -8,7 +8,7 @@
  * @since     0.1
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * Statify Uninstall
  *
  * @since 0.1
- * @since 2.0.0 renamed to Statify\Uninstall
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Uninstall
  */
 class Uninstall {
 

--- a/inc/Uninstall.php
+++ b/inc/Uninstall.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_Uninstall class
+ * Statify: Uninstall class
  *
  * This file contains the derived class for the plugin's uninstallation features.
  *
@@ -8,15 +8,18 @@
  * @since     0.1
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_Uninstall
+ * Statify Uninstall
  *
  * @since 0.1
+ * @since 2.0.0 renamed to Statify\Uninstall
  */
-class Statify_Uninstall {
+class Uninstall {
 
 	/**
 	 * Plugin uninstall handler.
@@ -71,9 +74,9 @@ class Statify_Uninstall {
 		delete_option( 'statify' );
 
 		// Init table.
-		Statify_Table::init();
+		Table::init();
 
 		// Delete table.
-		Statify_Table::drop();
+		Table::drop();
 	}
 }

--- a/inc/XMLRPC.php
+++ b/inc/XMLRPC.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify: Statify_XMLRPC class
+ * Statify: XMLRPC class
  *
  * This file contains the derived class for the plugin's XMLRPC features.
  *
@@ -8,15 +8,18 @@
  * @since     1.1
  */
 
+namespace Statify;
+
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Statify_XMLRPC
+ * Statify XMLRPC
  *
  * @since 1.1
+ * @since 2.0.0 renamed to Statify\XMLRPC
  */
-class Statify_XMLRPC {
+class XMLRPC {
 
 	/**
 	 * Enhancement from the XMLRPC-method.
@@ -70,7 +73,7 @@ class Statify_XMLRPC {
 		}
 
 		// Empty?
-		$data = Statify_Dashboard::get_stats();
+		$data = Dashboard::get_stats();
 		if ( ! $data ) {
 			return '{"error": "No data"}';
 		}

--- a/inc/Xmlrpc.php
+++ b/inc/Xmlrpc.php
@@ -8,7 +8,7 @@
  * @since     1.1
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 // Quit if accessed outside WP context.
 defined( 'ABSPATH' ) || exit;
@@ -17,9 +17,9 @@ defined( 'ABSPATH' ) || exit;
  * Statify XMLRPC
  *
  * @since 1.1
- * @since 2.0.0 renamed to Statify\XMLRPC
+ * @since 2.0.0 renamed to Pluginkollektiv\Statify\Xmlrpc
  */
-class XMLRPC {
+class Xmlrpc {
 
 	/**
 	 * Enhancement from the XMLRPC-method.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -33,6 +33,9 @@
         <exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized"/>
         <!-- Precision alignment is used in HTML views -->
         <exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+        <!-- PSR-4 autoloader -->
+        <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->

--- a/statify.php
+++ b/statify.php
@@ -7,7 +7,7 @@
  * Author URI:  https://pluginkollektiv.org/
  * Plugin URI:  https://statify.pluginkollektiv.org/
  * License:     GPLv3 or later
- * Version:     1.9.0
+ * Version:     2.0.0
  *
  * @package WordPress
  */
@@ -20,38 +20,14 @@ defined( 'ABSPATH' ) || exit;
 define( 'STATIFY_FILE', __FILE__ );
 define( 'STATIFY_DIR', dirname( __FILE__ ) );
 define( 'STATIFY_BASE', plugin_basename( __FILE__ ) );
-define( 'STATIFY_VERSION', '1.9.0' );
+define( 'STATIFY_VERSION', '2.0.0' );
 
 
 /* Hooks */
-add_action(
-	'plugins_loaded',
-	array(
-		'Statify\Statify',
-		'init',
-	)
-);
-register_activation_hook(
-	STATIFY_FILE,
-	array(
-		'Statify\Install',
-		'init',
-	)
-);
-register_deactivation_hook(
-	STATIFY_FILE,
-	array(
-		'Statify\Deactivate',
-		'init',
-	)
-);
-register_uninstall_hook(
-	STATIFY_FILE,
-	array(
-		'Statify\Uninstall',
-		'init',
-	)
-);
+add_action( 'plugins_loaded', array( 'Pluginkollektiv\Statify\Statify', 'init' ) );
+register_activation_hook( STATIFY_FILE, array( 'Pluginkollektiv\Statify\Install', 'init' ) );
+register_deactivation_hook( STATIFY_FILE, array( 'Pluginkollektiv\\Statify\Deactivate', 'init' ) );
+register_uninstall_hook( STATIFY_FILE, array( 'Pluginkollektiv\\Statify\Uninstall', 'init' ) );
 
 /* Composer Autoload */
 require __DIR__ . '/vendor/autoload.php';

--- a/statify.php
+++ b/statify.php
@@ -27,65 +27,31 @@ define( 'STATIFY_VERSION', '1.9.0' );
 add_action(
 	'plugins_loaded',
 	array(
-		'Statify',
+		'Statify\Statify',
 		'init',
 	)
 );
 register_activation_hook(
 	STATIFY_FILE,
 	array(
-		'Statify_Install',
+		'Statify\Install',
 		'init',
 	)
 );
 register_deactivation_hook(
 	STATIFY_FILE,
 	array(
-		'Statify_Deactivate',
+		'Statify\Deactivate',
 		'init',
 	)
 );
 register_uninstall_hook(
 	STATIFY_FILE,
 	array(
-		'Statify_Uninstall',
+		'Statify\Uninstall',
 		'init',
 	)
 );
 
 /* Composer Autoload */
 require __DIR__ . '/vendor/autoload.php';
-
-/* Autoload */
-spl_autoload_register( 'statify_autoload' );
-
-/**
- * Include classes via autoload.
- *
- * @param string $class Name of an class-file name, without file extension.
- */
-function statify_autoload( $class ) {
-
-	$plugin_classes = array(
-		'Statify',
-		'Statify_Api',
-		'Statify_Backend',
-		'Statify_Frontend',
-		'Statify_Dashboard',
-		'Statify_Install',
-		'Statify_Uninstall',
-		'Statify_Deactivate',
-		'Statify_Settings',
-		'Statify_Table',
-		'Statify_XMLRPC',
-		'Statify_Cron',
-	);
-
-	if ( in_array( $class, $plugin_classes, true ) ) {
-		require_once sprintf(
-			'%s/inc/class-%s.php',
-			STATIFY_DIR,
-			strtolower( str_replace( '_', '-', $class ) )
-		);
-	}
-}

--- a/tests/test-api-tracking.php
+++ b/tests/test-api-tracking.php
@@ -5,6 +5,12 @@
  * @package Statify
  */
 
+namespace Statify;
+
+use DateTime;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
 /**
  * Class Test_Api_Tracking.
  * Tests for JavaScript based tracking using WP API.
@@ -19,7 +25,7 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 		parent::set_up();
 
 		// "Install" Statify, i.e. create tables and options.
-		Statify_Install::init();
+		Install::init();
 	}
 
 	/**
@@ -35,16 +41,16 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 
 		do_action( 'rest_api_init' );
 		$this->assertArrayNotHasKey(
-			'/' . Statify_Api::REST_NAMESPACE . '/' . Statify_Api::REST_ROUTE_TRACK,
+			'/' . Api::REST_NAMESPACE . '/' . Api::REST_ROUTE_TRACK,
 			$wp_rest_server->get_routes(),
 			'REST route should not have been registered with JS disabled'
 		);
 
 		// Enable JS tracking.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK );
 		do_action( 'rest_api_init' );
 		$this->assertArrayHasKey(
-			'/' . Statify_Api::REST_NAMESPACE . '/' . Statify_Api::REST_ROUTE_TRACK,
+			'/' . Api::REST_NAMESPACE . '/' . Api::REST_ROUTE_TRACK,
 			$wp_rest_server->get_routes(),
 			'REST route should have been registered with JS enabled'
 		);
@@ -59,7 +65,7 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 		// Initialize a valid Statify tracking request.
 		$request = new WP_REST_Request(
 			'POST',
-			'/' . Statify_Api::REST_NAMESPACE . '/' . Statify_Api::REST_ROUTE_TRACK
+			'/' . Api::REST_NAMESPACE . '/' . Api::REST_ROUTE_TRACK
 		);
 		$request->set_header( 'Content-Type', 'appliction/json;charset=utf-8' );
 		$request->set_param( 'target', '/' );
@@ -67,7 +73,7 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 		$request->set_param( 'nonce', wp_create_nonce( 'statify_track' ) );
 
 		// Initialize Statify with JS tracking enabled.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK );
 		do_action( 'rest_api_init' );
 
 		$response = $wp_rest_server->dispatch( $request );
@@ -108,7 +114,7 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 		$this->assertEquals( 1, $stats['visits'][0]['count'], 'Visit count should not be higher after AJAX request failed' );
 
 		// Now disable JS tracking.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_DEFAULT );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_DEFAULT );
 
 		// The REST routes for testing are not reset, so the endpoint is evaluated and does not return 404 here.
 		$response = $wp_rest_server->dispatch( $request );
@@ -118,7 +124,7 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 		$this->assertEquals( 1, $stats['referrer'][0]['count'], 'Unexpected referrer count' );
 
 		// Re-enable JS without nonce.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK );
 
 		$response = $wp_rest_server->dispatch( $request );
 		$this->assertEquals( 204, $response->get_status(), 'API request should return 204 with JS enabled' );
@@ -136,7 +142,7 @@ class Test_Api_Tracking extends WP_UnitTestCase {
 
 		/* Allow tracking for logged-in users.
 		   This also check the overruled check, i.e. the login status is not reset without nonce. */
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK, true );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK, true );
 		$response = $wp_rest_server->dispatch( $request );
 		$this->assertEquals( 204, $response->get_status(), 'API request should return 204 with JS enabled and logged in' );
 		$stats = $this->get_stats();

--- a/tests/test-api-tracking.php
+++ b/tests/test-api-tracking.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use DateTime;
 use WP_REST_Request;

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -5,6 +5,11 @@
  * @package Statify
  */
 
+namespace Statify;
+
+use DateTime;
+use WP_UnitTestCase;
+
 /**
  * Class Test_Cron.
  * Tests for cron integration.
@@ -19,7 +24,7 @@ class Test_Cron extends WP_UnitTestCase {
 		parent::set_up();
 
 		// "Install" Statify, i.e. create tables and options.
-		Statify_Install::init();
+		Install::init();
 	}
 
 	/**
@@ -32,7 +37,7 @@ class Test_Cron extends WP_UnitTestCase {
 		// Initialize normal cycle, configure storage period of 3 days.
 		$this->init_statify_widget( 3 );
 		$this->assertNotFalse(
-			has_action( 'statify_cleanup', array( 'Statify_Cron', 'cleanup_data' ) ),
+			has_action( 'statify_cleanup', array( 'Statify\Cron', 'cleanup_data' ) ),
 			'Statify cleanup cron job should be registered in normal cycle (always)'
 		);
 
@@ -40,7 +45,7 @@ class Test_Cron extends WP_UnitTestCase {
 		define( 'DOING_CRON', true );
 		Statify::init();
 		$this->assertNotFalse(
-			has_action( 'statify_cleanup', array( 'Statify_Cron', 'cleanup_data' ) ),
+			has_action( 'statify_cleanup', array( 'Statify\Cron', 'cleanup_data' ) ),
 			'Statify cleanup cron job was not registered'
 		);
 
@@ -62,7 +67,7 @@ class Test_Cron extends WP_UnitTestCase {
 		}
 
 		// Run the cron job.
-		Statify_Cron::cleanup_data();
+		Cron::cleanup_data();
 
 		// Verify that 2 days have been deleted.
 		$stats = $this->get_stats();

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use DateTime;
 use WP_UnitTestCase;
@@ -37,7 +37,7 @@ class Test_Cron extends WP_UnitTestCase {
 		// Initialize normal cycle, configure storage period of 3 days.
 		$this->init_statify_widget( 3 );
 		$this->assertNotFalse(
-			has_action( 'statify_cleanup', array( 'Statify\Cron', 'cleanup_data' ) ),
+			has_action( 'statify_cleanup', array( 'Pluginkollektiv\Statify\Cron', 'cleanup_data' ) ),
 			'Statify cleanup cron job should be registered in normal cycle (always)'
 		);
 
@@ -45,7 +45,7 @@ class Test_Cron extends WP_UnitTestCase {
 		define( 'DOING_CRON', true );
 		Statify::init();
 		$this->assertNotFalse(
-			has_action( 'statify_cleanup', array( 'Statify\Cron', 'cleanup_data' ) ),
+			has_action( 'statify_cleanup', array( 'Pluginkollektiv\Statify\Cron', 'cleanup_data' ) ),
 			'Statify cleanup cron job was not registered'
 		);
 

--- a/tests/test-dashboard.php
+++ b/tests/test-dashboard.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use DateTime;
 use WP_UnitTestCase;
@@ -28,7 +28,9 @@ class Test_Dashboard extends WP_UnitTestCase {
 		// "Install" Statify, i.e. create tables and options.
 		Install::init();
 
-		if ( ! function_exists( 'Statify\wp_add_dashboard_widget' ) ) {
+		/* This function is typically defined in the root namespace. However, the hierarchy prefers this overridden
+		   instance here, so it will be used for testing purposes. */
+		if ( ! function_exists( 'Pluginkollektiv\Statify\wp_add_dashboard_widget' ) ) {
 			global $widget_capture;
 			$widget_capture = array();
 

--- a/tests/test-dashboard.php
+++ b/tests/test-dashboard.php
@@ -5,6 +5,11 @@
  * @package Statify
  */
 
+namespace Statify;
+
+use DateTime;
+use WP_UnitTestCase;
+
 /**
  * Class Test_Dashboard.
  * Tests for dashboard integration.
@@ -21,9 +26,9 @@ class Test_Dashboard extends WP_UnitTestCase {
 		set_current_screen( 'dashboard' );
 
 		// "Install" Statify, i.e. create tables and options.
-		Statify_Install::init();
+		Install::init();
 
-		if ( ! function_exists( 'wp_add_dashboard_widget' ) ) {
+		if ( ! function_exists( 'Statify\wp_add_dashboard_widget' ) ) {
 			global $widget_capture;
 			$widget_capture = array();
 
@@ -57,13 +62,13 @@ class Test_Dashboard extends WP_UnitTestCase {
 
 		// Anonymous users do not have the "edit_dashboard" capability, i.e. can't see the stats.
 		wp_set_current_user( 0 );
-		Statify_Dashboard::init();
+		Dashboard::init();
 		$this->assertFalse(
-			has_action( 'admin_print_styles', array( Statify_Dashboard::class, 'add_style' ) ),
+			has_action( 'admin_print_styles', array( Dashboard::class, 'add_style' ) ),
 			'Styles unexpectedly added'
 		);
 		$this->assertFalse(
-			has_action( 'admin_print_scripts', array( Statify_Dashboard::class, 'add_js' ) ),
+			has_action( 'admin_print_scripts', array( Dashboard::class, 'add_js' ) ),
 			'Scripts unexpectedly added'
 		);
 
@@ -71,26 +76,26 @@ class Test_Dashboard extends WP_UnitTestCase {
 		wp_get_current_user()->add_cap( 'edit_dashboard' );
 		wp_set_current_user( 1 );
 
-		Statify_Dashboard::init();
+		Dashboard::init();
 		$this->assertCount( 5, $widget_capture, 'No widget registered' );
 		$this->assertEquals( 'statify_dashboard', $widget_capture['widget_id'], 'Unexpected widget ID' );
 		$this->assertEquals( 'Statify', $widget_capture['widget_name'], 'Unexpected widget name' );
 		$this->assertEquals(
-			array( Statify_Dashboard::class, 'print_frontview' ),
+			array( Dashboard::class, 'print_frontview' ),
 			$widget_capture['callback'],
 			'Unexpected widget callback'
 		);
 		$this->assertEquals(
-			array( Statify_Dashboard::class, 'print_backview' ),
+			array( Dashboard::class, 'print_backview' ),
 			$widget_capture['control_callback'],
 			'Unexpected control callback'
 		);
 		$this->assertNotFalse(
-			has_action( 'admin_print_styles', array( Statify_Dashboard::class, 'add_style' ) ),
+			has_action( 'admin_print_styles', array( Dashboard::class, 'add_style' ) ),
 			'Styles not added'
 		);
 		$this->assertNotFalse(
-			has_action( 'admin_print_scripts', array( Statify_Dashboard::class, 'add_js' ) ),
+			has_action( 'admin_print_scripts', array( Dashboard::class, 'add_js' ) ),
 			'Scripts not added'
 		);
 	}
@@ -119,7 +124,7 @@ class Test_Dashboard extends WP_UnitTestCase {
 		$widget_capture = array();
 		$override       = true;
 
-		Statify_Dashboard::init();
+		Dashboard::init();
 		$this->assertCount( 5, $widget_capture, 'Widget should not have been registered' );
 		$this->assertFalse( $original_capture, 'Expected original result to be FALSE' );
 
@@ -128,7 +133,7 @@ class Test_Dashboard extends WP_UnitTestCase {
 		wp_get_current_user()->add_cap( 'edit_dashboard' );
 		$override = false;
 
-		Statify_Dashboard::init();
+		Dashboard::init();
 		$this->assertEmpty( $widget_capture, 'Widget should not have been registered' );
 		$this->assertTrue( $original_capture, 'Expected original result to be TRUE' );
 	}
@@ -254,13 +259,13 @@ class Test_Dashboard extends WP_UnitTestCase {
 
 		// Finally we add another entry in the database, but utilize the transient cache (4min should be enough for the test case).
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://example.com/', '/example/', 1 );
-		$stats4 = Statify_Dashboard::get_stats();
+		$stats4 = Dashboard::get_stats();
 		$this->assertEquals( $stats3, $stats4, 'Stats expected to be equal, is the transient cache active?' );
 
 		// Add more data and force reload. We now should see that fallback ordering by URL works.
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://example.com/', '/', 1 );
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://example.net/', '/', 1 );
-		$stats5 = Statify_Dashboard::get_stats( true );
+		$stats5 = Dashboard::get_stats( true );
 		$this->assertEquals( 18, $stats5['visit_totals']['since_beginning']['count'], 'Unexpected total since beginning' );
 		$this->assertEquals( 2, $stats5['referrer'][1]['count'], 'Unexpected 2nd referrer count' );
 		$this->assertEquals( 'example.com', $stats5['referrer'][1]['host'], 'Unexpected 2nd referrer hostname' );

--- a/tests/test-frontend.php
+++ b/tests/test-frontend.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use WP_UnitTestCase;
 
@@ -23,7 +23,7 @@ class Test_Frontend extends WP_UnitTestCase {
 		// Disable JS tracking.
 		$this->init_statify_tracking( Statify::TRACKING_METHOD_DEFAULT );
 		$this->assertNotFalse(
-			has_action( 'wp_footer', array( 'Statify\Frontend', 'wp_footer' ) ),
+			has_action( 'wp_footer', array( 'Pluginkollektiv\Statify\Frontend', 'wp_footer' ) ),
 			'Statify footer action not registered'
 		);
 
@@ -58,7 +58,7 @@ class Test_Frontend extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action(
 				'query_vars',
-				array( 'Statify\Frontend', 'query_vars' )
+				array( 'Pluginkollektiv\Statify\Frontend', 'query_vars' )
 			),
 			'Statify query_vars action not registered'
 		);

--- a/tests/test-frontend.php
+++ b/tests/test-frontend.php
@@ -5,6 +5,10 @@
  * @package Statify
  */
 
+namespace Statify;
+
+use WP_UnitTestCase;
+
 /**
  * Class Test_Frontend.
  * Tests for frontend integration.
@@ -17,22 +21,22 @@ class Test_Frontend extends WP_UnitTestCase {
 	 */
 	public function test_wp_footer() {
 		// Disable JS tracking.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_DEFAULT );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_DEFAULT );
 		$this->assertNotFalse(
-			has_action( 'wp_footer', array( 'Statify_Frontend', 'wp_footer' ) ),
+			has_action( 'wp_footer', array( 'Statify\Frontend', 'wp_footer' ) ),
 			'Statify footer action not registered'
 		);
 
-		Statify_Frontend::wp_footer();
+		Frontend::wp_footer();
 		$this->assertFalse(
 			wp_script_is( 'statify-js', 'enqueued' ),
 			'Statify JS should not be enqueued if JS tracking is disabled'
 		);
 
 		// Enable JS tracking.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK );
 
-		Statify_Frontend::wp_footer();
+		Frontend::wp_footer();
 		$this->assertTrue(
 			wp_script_is( 'statify-js', 'enqueued' ),
 			'Statify JS must be equeued if JS tracking is enabled'
@@ -54,12 +58,12 @@ class Test_Frontend extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action(
 				'query_vars',
-				array( 'Statify_Frontend', 'query_vars' )
+				array( 'Statify\Frontend', 'query_vars' )
 			),
 			'Statify query_vars action not registered'
 		);
 
-		$vars = Statify_Frontend::query_vars( array() );
+		$vars = Frontend::query_vars( array() );
 		$this->assertCount( 2, $vars, 'Unexpected number of query vars' );
 		$this->assertContains( 'statify_referrer', $vars, 'Referrer variable not declared' );
 		$this->assertContains( 'statify_target', $vars, 'Target variable not declared' );

--- a/tests/test-statify.php
+++ b/tests/test-statify.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use WP_UnitTestCase;
 

--- a/tests/test-statify.php
+++ b/tests/test-statify.php
@@ -5,6 +5,10 @@
  * @package Statify
  */
 
+namespace Statify;
+
+use WP_UnitTestCase;
+
 /**
  * Class Test_Statify.
  * Tests for Statify core class.
@@ -19,7 +23,7 @@ class Test_Statify extends WP_UnitTestCase {
 		parent::set_up();
 
 		// "Install" Statify, i.e. create tables and options.
-		Statify_Install::init();
+		Install::init();
 	}
 
 	/**

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 use DateTime;
 use WP_UnitTestCase;
@@ -40,7 +40,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action(
 				'template_redirect',
-				array( 'Statify\Frontend', 'track_visit' )
+				array( 'Pluginkollektiv\Statify\Frontend', 'track_visit' )
 			),
 			'Statify tracking action not registered'
 		);

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -5,6 +5,11 @@
  * @package Statify
  */
 
+namespace Statify;
+
+use DateTime;
+use WP_UnitTestCase;
+
 /**
  * Class Test_Tracking.
  * Tests for non-JavaScript tracking and tracking-related mechanisms.
@@ -19,7 +24,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		parent::set_up();
 
 		// "Install" Statify, i.e. create tables and options.
-		Statify_Install::init();
+		Install::init();
 	}
 
 	/**
@@ -35,7 +40,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action(
 				'template_redirect',
-				array( 'Statify_Frontend', 'track_visit' )
+				array( 'Statify\Frontend', 'track_visit' )
 			),
 			'Statify tracking action not registered'
 		);
@@ -45,7 +50,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		$_SERVER['HTTP_REFERER']    = 'https://statify.pluginkollektiv.org/';
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36';
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 
 		$this->assertNotNull( $stats, 'Stats should be filled after tracking' );
@@ -68,7 +73,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		$_SERVER['REQUEST_URI']     = '/';
 		$_SERVER['HTTP_REFERER']    = 'https://statify.pluginkollektiv.org/documentation/';
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:77.0) Gecko/20100101 Firefox/77.0';
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 
 		$stats = $this->get_stats();
 		$this->assertNotNull( $stats, 'Stats should be filled after tracking' );
@@ -88,7 +93,7 @@ class Test_Tracking extends WP_UnitTestCase {
 
 		// Request to invalid target should not be tracked.
 		$_SERVER['REQUEST_URI'] = '';
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 2, $stats['visits'][0]['count'], 'Unexpected visit count' );
 
@@ -97,7 +102,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		$_SERVER['REQUEST_URI']  = '/?foo=bar';
 		$_SERVER['HTTP_REFERER'] = home_url();
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 3, $stats['visits'][0]['count'], 'Unexpected visit count' );
 		$this->assertEquals( 2, count( $stats['target'] ), 'Unexpected number of targets' );
@@ -109,8 +114,8 @@ class Test_Tracking extends WP_UnitTestCase {
 
 		// If JavaScript tracking is enabled, the regular request should not be tracked.
 		$_SERVER['REQUEST_URI'] = '/';
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK, false );
-		Statify_Frontend::track_visit();
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK, false );
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 3, $stats['visits'][0]['count'], 'Unexpected visit count' );
 	}
@@ -132,31 +137,31 @@ class Test_Tracking extends WP_UnitTestCase {
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36';
 
 		$wp_query->is_robots = true;
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, 'Robots should not be tracked' );
 
 		$wp_query->is_robots    = false;
 		$wp_query->is_trackback = true;
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, 'Trackbacks should not be tracked.' );
 
 		$wp_query->is_trackback = false;
 		$wp_query->is_preview   = true;
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, 'Previews should not be tracked.' );
 
 		$wp_query->is_preview = false;
 		$wp_query->is_404     = true;
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, '404 should not be tracked.' );
 
 		$wp_query->is_404  = false;
 		$wp_query->is_feed = true;
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, 'Feeds should not be tracked.' );
 
@@ -164,7 +169,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		$wp_query->is_feed = false;
 		if ( function_exists( 'is_favicon' ) ) {
 			$wp_query->is_favicon = true;
-			Statify_Frontend::track_visit();
+			Frontend::track_visit();
 			$stats = $this->get_stats();
 			$this->assertNull( $stats, 'Favicons should not be tracked.' );
 			$wp_query->is_favicon = false;
@@ -173,12 +178,12 @@ class Test_Tracking extends WP_UnitTestCase {
 		// Sitemap XML and XSL for WP 5.5 and above.
 		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
 			set_query_var( 'sitemap', 'index' );
-			Statify_Frontend::track_visit();
+			Frontend::track_visit();
 			$stats = $this->get_stats();
 			$this->assertNull( $stats, 'Sitemap XML should not be tracked.' );
 			set_query_var( 'sitemap', null );
 			set_query_var( 'sitemap-stylesheet', 'sitemap' );
-			Statify_Frontend::track_visit();
+			Frontend::track_visit();
 			$stats = $this->get_stats();
 			$this->assertNull( $stats, 'Sitemap XSL should not be tracked.' );
 		}
@@ -241,7 +246,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		foreach ( $bot_uas as $bot_ua ) {
 			$_SERVER['HTTP_USER_AGENT'] = $bot_ua;
 
-			Statify_Frontend::track_visit();
+			Frontend::track_visit();
 			$stats = $this->get_stats();
 			$this->assertNull( $stats, 'Bot exclusion failed for user agent: ' . $bot_ua );
 		}
@@ -260,19 +265,19 @@ class Test_Tracking extends WP_UnitTestCase {
 			"example.com\nstatify.pluginkollektiv.org\nexample.net"
 		);
 
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_DEFAULT, false, true );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_DEFAULT, false, true );
 
 		// Basically a valid request.
 		$_SERVER['REQUEST_URI']     = '/';
 		$_SERVER['HTTP_REFERER']    = 'https://statify.pluginkollektiv.org/';
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36';
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, 'Tracking for blacklisted referrer succeeded' );
 
 		$this->init_statify_tracking();
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNotNull( $stats, 'Blacklist evaluated when not enabled' );
 	}
@@ -303,7 +308,7 @@ class Test_Tracking extends WP_UnitTestCase {
 			}
 		);
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 1, $stats['visits'][0]['count'], 'Filter result NULL should not affect counting' );
 		$this->assertNull( $capture, 'Initial filter should receive NULL value as previous result' );
@@ -311,7 +316,7 @@ class Test_Tracking extends WP_UnitTestCase {
 		// Explicitly blacklist request.
 		$filter_result = true;
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 1, $stats['visits'][0]['count'], 'Filter result FALSE should prevent request from being tracked' );
 
@@ -319,14 +324,14 @@ class Test_Tracking extends WP_UnitTestCase {
 		$filter_result    = null;
 		$wp_query->is_404 = true;
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 1, $stats['visits'][0]['count'], 'Filter result NULL should not affect built-in filters' );
 
 		// We now explicitly NOT skip the request.
 		$filter_result = false;
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertEquals( 2, $stats['visits'][0]['count'], 'Filter result TRUE should force counting' );
 	}
@@ -356,7 +361,7 @@ class Test_Tracking extends WP_UnitTestCase {
 			2
 		);
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNotNull( $stats['visits'][0]['count'], 'Request not tracked' );
 		$this->assertNotEmpty( $capture, 'Hook stativy__visit_saved has not fired' );
@@ -385,14 +390,14 @@ class Test_Tracking extends WP_UnitTestCase {
 		$_SERVER['HTTP_REFERER']    = 'https://statify.pluginkollektiv.org/';
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36';
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNull( $stats, 'Logged-in user should not be tracked' );
 
 		// Re-initialize Statify, enabling logged-in user tracking.
-		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_DEFAULT, true );
+		$this->init_statify_tracking( Statify::TRACKING_METHOD_DEFAULT, true );
 
-		Statify_Frontend::track_visit();
+		Frontend::track_visit();
 		$stats = $this->get_stats();
 		$this->assertNotNull( $stats, 'Logged-in user should be tracked' );
 	}

--- a/tests/trait-statify-test-support.php
+++ b/tests/trait-statify-test-support.php
@@ -5,7 +5,7 @@
  * @package Statify
  */
 
-namespace Statify;
+namespace Pluginkollektiv\Statify;
 
 /**
  * Trait Statify_Test_Support.

--- a/tests/trait-statify-test-support.php
+++ b/tests/trait-statify-test-support.php
@@ -5,6 +5,8 @@
  * @package Statify
  */
 
+namespace Statify;
+
 /**
  * Trait Statify_Test_Support.
  *
@@ -79,7 +81,7 @@ trait Statify_Test_Support {
 	protected function get_stats() {
 		delete_transient( 'statify_data' );
 
-		return Statify_Dashboard::get_stats();
+		return Dashboard::get_stats();
 	}
 
 	/**

--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -7,8 +7,10 @@
  * @package   Statify
  */
 
+namespace Pluginkollektiv\Statify;
+
 // Quit if accessed outside WP context.
-class_exists( 'Statify' ) || exit; ?>
+class_exists( 'Pluginkollektiv\Statify\Statify' ) || exit; ?>
 
 <?php if ( current_user_can( 'manage_options' ) ) : ?>
 <p class="meta-links settings-link">

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -7,8 +7,10 @@
  * @package   Statify
  */
 
+namespace Pluginkollektiv\Statify;
+
 // Quit if accessed outside WP context.
-class_exists( 'Statify' ) || exit;
+class_exists( 'Pluginkollektiv\Statify\Statify' ) || exit;
 
 $limit       = (int) Statify::$_options['limit'];
 $show_totals = (int) Statify::$_options['show_totals'];


### PR DESCRIPTION
This PR is **WORK IN PROGRESS** and not yet ready to be merged.

----

This proposal does change the project structure and class names.

First we introduce a `Pluginkollektiv\Statify\` namespace and move the classes into it stripping their prefixes, i.e. `Statify_Frontend` will become `Pluginkollektiv\Statify\Frontend`.
Then we introduce a PSR-4 autoloader with _Composer_ and replace our custom autoloading function.

ToDo:
* Find a different way to minify our CS/JS resources, because this currently requires dev-dependencies, so the mechanism is not yet suitable for production.
  * Might be a pre-commit hook that generates them, so they are kept in the source tree while still be automatically generated.
* Point third-party CSS/JS to the vendor directory.
* Discuss, whether we want to go that way (probably do this first place)