### PR TITLE
fix text alignment in dashboard widget (#263)

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -3,7 +3,6 @@
 #statify_chart {
 	color: #a7aaad;
 	flex: 0 0 100%;
-	direction: rtl;
 	height: 140px;
 	margin: 1em -0.5em;
 	overflow-x: auto;
@@ -11,16 +10,17 @@
 	text-align: center;
 }
 
+#statify_chart * {
+	direction: ltr;
+}
+
+body.rtl #statify_chart * {
+	direction: rtl;
+}
+
 #statify_chart .spinner {
 	float: none;
 	margin: 1em;
-}
-
-#statify_chart .ct-label.ct-vertical.ct-start {
-	-webkit-justify-content: flex-start;
-	justify-content: flex-start;
-	text-align: left;
-	text-anchor: start;
 }
 
 #statify_chart .ct-line {


### PR DESCRIPTION
We use RTL direction for the chart container in order see the rightmost data when the chart has a horizontal scrollbar. This however results in wrong text layout if there is no data or an error occurred.

Revert the text direction for all child elements and remove the custom flex overrides for the chart labels.

resolves #263 

----
The scrollbar is right by default:
![statify-264-01](https://github.com/pluginkollektiv/statify/assets/12963621/52ae1bf7-552d-4c73-80b4-87b45ea81be6)

The labels are right-aligned:
![statify-264-02](https://github.com/pluginkollektiv/statify/assets/12963621/22868d45-72e7-4999-917e-2391e5259844)

Inner text is displayed in default direction:
![statify-264-03](https://github.com/pluginkollektiv/statify/assets/12963621/f8aa0157-1615-45e1-be29-eeb891b404fa)

And on sites with RTL languages, too:
![statify-264-04](https://github.com/pluginkollektiv/statify/assets/12963621/0f09d79b-d74f-4197-a651-56b1a5a384f5)
