### PR TITLE
Also create the `stats` API endpoint for no-JS tracking (#270)

### DIFF
--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -32,16 +32,18 @@ class Statify_Api extends Statify {
 	 * @return void
 	 */
 	public static function init() {
-		register_rest_route(
-			self::REST_NAMESPACE,
-			self::REST_ROUTE_TRACK,
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'accept_json'         => true,
-				'callback'            => array( __CLASS__, 'track_visit' ),
-				'permission_callback' => '__return_true',
-			)
-		);
+		if ( Statify::is_javascript_tracking_enabled() ) {
+			register_rest_route(
+				self::REST_NAMESPACE,
+				self::REST_ROUTE_TRACK,
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'accept_json'         => true,
+					'callback'            => array( __CLASS__, 'track_visit' ),
+					'permission_callback' => '__return_true',
+				)
+			);
+		}
 
 		register_rest_route(
 			self::REST_NAMESPACE,

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -89,9 +89,7 @@ class Statify {
 				add_filter( 'amp_post_template_analytics', array( 'Statify_Frontend', 'amp_post_template_analytics' ) );
 			}
 			// Initialize REST API.
-			if ( self::is_javascript_tracking_enabled() ) {
-				add_filter( 'rest_api_init', array( 'Statify_Api', 'init' ) );
-			}
+			add_filter( 'rest_api_init', array( 'Statify_Api', 'init' ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #270 