### PR TITLE
preserve NULL for "show_widget_roles" option, if unset

### DIFF
--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -413,8 +413,7 @@ class Statify_Settings {
 			}
 		}
 
-		// Sanitize user roles.
-		$res['show_widget_roles'] = array();
+		// Sanitize user roles (preserve NULL, if unset).
 		if ( isset( $options['show_widget_roles'] ) ) {
 			$available_roles = apply_filters( 'statify__available_roles', wp_roles()->roles );
 			foreach ( $options['show_widget_roles'] as $saved_role ) {


### PR DESCRIPTION
## Steps to reproduce

1. Install _Statify_ on a fresh site or update from 1.x to 2.0 (no `show_widget_roles` option set).
2. Click on "Configuration" (reduced settings tab) on the dashboard widget
3. Save options (no changes needed)

## Observed (mis)behavior

Widget is gone, i.e. nobody can see it.

We set a default `'show_widget_roles' => array()` unconditionally. Empty array is equivalent to "no roles checked", so nobody can see anything.

## Solution

Preserve `null` or unset options and only sanitize, if actually set.

