### PR TITLE
move invisible tooltip to the top left corner to prevent layout shift

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -42,7 +42,9 @@ body.rtl #statify_chart * {
 	border: 1px solid #000;
 	background-color: #fff;
 	border-radius: 0.2em;
+	left: 0;
 	padding: 0.1em 0.5em;
+	top: 0;
 }
 
 .statify-chartist-tooltip::before {


### PR DESCRIPTION
**Describe the bug**

The tooltip is placed at the bottom of the body which makes the page slightly longer, even though the user can't see the content. This might result in a layout shift when the tooltip is displayed for the first time and the scrollbar disappears.

**To Reproduce**

1. Visit a site dashboard with the _Statify_ widget enabled and some data present in the database.
2. Keep an eye on the page layout and the scrollbar, if visible.
3. Hover over any data point in the _Statify_ chart (shows tooltip)
4. See the layout and/or scrollbar shift.

![statify-tooltip-shift](https://github.com/pluginkollektiv/statify/assets/12963621/2754a173-1f07-4b67-8731-be9ad9ae4f88)

**Expected behavior**

Tooltip is displayed without additional layout shift.

----

**Solution**

Move the invisible tooltip element to the top-left corner fixes this issue. We use left/top CSS properties, because these two will be dynamically overwritten on mouse events anyway.