### PR TITLE
Fix user role error on saving settings

### DIFF
--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -416,6 +416,7 @@ class Statify_Settings {
 		// Sanitize user roles (preserve NULL, if unset).
 		if ( isset( $options['show_widget_roles'] ) ) {
 			$available_roles = apply_filters( 'statify__available_roles', wp_roles()->roles );
+			$res['show_widget_roles'] = array();
 			foreach ( $options['show_widget_roles'] as $saved_role ) {
 				if ( in_array( $saved_role, array_keys( $available_roles ), true ) ) {
 					array_push( $res['show_widget_roles'], $saved_role );

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Statify settings tests.
+ *
+ * @package Statify
+ */
+
+/**
+ * Class Test_Settings.
+ * Tests for settings page.
+ */
+class Test_Settings extends WP_UnitTestCase {
+	use Statify_Test_Support;
+
+	/**
+	 * Test Statify Dashboard initialization.
+	 */
+	public function test_sanitize_options() {
+		self::assertSame(
+			array(
+				'days'        => 14,
+				'days_show'   => 14,
+				'limit'       => 3,
+				'today'       => 0,
+				'blacklist'   => 0,
+				'show_totals' => 0,
+			),
+			Statify_Settings::sanitize_options( array() ),
+			'unexpected results for empty input'
+		);
+
+		self::assertSame(
+			array(
+				'days'        => 15,
+				'days_show'   => 13,
+				'limit'       => 4,
+				'today'       => 1,
+				'blacklist'   => 0,
+				'show_totals' => 1,
+			),
+			Statify_Settings::sanitize_options(
+				array(
+					'days'        => '15',
+					'days_show'   => '13',
+					'limit'       => '4',
+					'today'       => '1',
+					'blacklist'   => 5,
+					'show_totals' => '1',
+				)
+			),
+			'string values should be sanitized to numbers or 1/0 for boolean flags'
+		);
+
+		self::assertSame(
+			array(
+				'days'              => 14,
+				'days_show'         => 14,
+				'limit'             => 3,
+				'today'             => 0,
+				'blacklist'         => 0,
+				'show_totals'       => 0,
+				'show_widget_roles' => array( 'administrator', 'author' ),
+			),
+			Statify_Settings::sanitize_options(
+				array(
+					'show_widget_roles' => array( 'administrator', '', 'author', 'doesnotexist' ),
+				)
+			),
+			'unknown widget roles should have been removed'
+		);
+	}
+}

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -16,6 +16,21 @@ class Test_Settings extends WP_UnitTestCase {
 	 * Test Statify Dashboard initialization.
 	 */
 	public function test_sanitize_options() {
+		// Reset options to default.
+		Statify::$_options = array(
+			'days'              => 14,
+			'days_show'         => 14,
+			'limit'             => 3,
+			'today'             => 0,
+			'snippet'           => 0,
+			'blacklist'         => 0,
+			'show_totals'       => 0,
+			'show_widget_roles' => null, // Just for documentation, the default is calculated later.
+			'skip'              => array(
+				'logged_in' => Statify::SKIP_USERS_ALL,
+			),
+		);
+
 		self::assertSame(
 			array(
 				'days'        => 14,

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -25,7 +25,7 @@ class Test_Settings extends WP_UnitTestCase {
 			'snippet'           => 0,
 			'blacklist'         => 0,
 			'show_totals'       => 0,
-			'show_widget_roles' => null, // Just for documentation, the default is calculated later.
+			'show_widget_roles' => null,
 			'skip'              => array(
 				'logged_in' => Statify::SKIP_USERS_ALL,
 			),
@@ -64,6 +64,61 @@ class Test_Settings extends WP_UnitTestCase {
 				)
 			),
 			'string values should be sanitized to numbers or 1/0 for boolean flags'
+		);
+
+		self::assertSame(
+			array(
+				'days'        => 14,
+				'days_show'   => 14,
+				'limit'       => 100,
+				'today'       => 0,
+				'blacklist'   => 0,
+				'show_totals' => 0,
+			),
+			Statify_Settings::sanitize_options( array( 'limit' => 101 ) ),
+			'limit was not capped at 100'
+		);
+
+		self::assertSame(
+			array(
+				'days'        => 14,
+				'days_show'   => 14,
+				'limit'       => 3,
+				'snippet'     => 1,
+				'today'       => 0,
+				'blacklist'   => 0,
+				'show_totals' => 0,
+				'skip'        => array(
+					'logged_in' => 0,
+				),
+			),
+			Statify_Settings::sanitize_options(
+				array(
+					'snippet' => '1',
+					'skip'    => array(
+						'logged_in' => '0',
+					),
+				)
+			),
+			'valid "snippet" and "logged_in" settings not passed through'
+		);
+
+		self::assertSame(
+			array(
+				'days'        => 14,
+				'days_show'   => 14,
+				'limit'       => 3,
+				'today'       => 0,
+				'blacklist'   => 0,
+				'show_totals' => 0,
+			),
+			Statify_Settings::sanitize_options(
+				array(
+					'snippet'   => 3,
+					'logged_in' => -1,
+				)
+			),
+			'illegal "snippet" and "logged_in" settings not removed'
 		);
 
 		self::assertSame(


### PR DESCRIPTION
This PR adds an empty user role array before pushing any new user role.

Fixes #278 