### PR TITLE
update requirements to PHP 7.2 and WP 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         include:
           - php: '7.2'
-            wordpress: '4.7'
+            wordpress: '5.1'
           - php: '7.4'
             wordpress: '5.9'
           - php: '8.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '5.6'
+          - php: '7.2'
             wordpress: '4.7'
           - php: '7.4'
             wordpress: '5.9'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         include:
           - php: '7.2'
-            wordpress: '5.1'
+            wordpress: '5.2'
           - php: '7.4'
             wordpress: '5.9'
           - php: '8.0'

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "statistics"
   ],
   "require": {
-    "php": "^5.3|^7|^8",
+    "php": "^7.2|^8",
     "npm-asset/chartist": "^1.3.0",
     "npm-asset/chartist-plugin-tooltips-updated": "^1.0.0",
     "jaybizzle/crawler-detect": "^1.2"
@@ -21,7 +21,7 @@
     "squizlabs/php_codesniffer": "^3.9",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "wp-coding-standards/wpcs": "^3.1",
-    "phpunit/phpunit": "^5|^7|^9",
+    "phpunit/phpunit": "^7|^9",
     "yoast/phpunit-polyfills": "^2.0"
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "wp-coding-standards/wpcs": "^3.1",
     "phpunit/phpunit": "^7|^9",
-    "yoast/phpunit-polyfills": "^2.0"
+    "yoast/phpunit-polyfills": "^1.1"
   },
   "repositories": [
     {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,7 @@
     <exclude-pattern>vendor/*</exclude-pattern>
 
     <!-- WordPress coding standards -->
-    <config name="minimum_supported_wp_version" value="4.7" />
+    <config name="minimum_supported_wp_version" value="5.1" />
     <rule ref="WordPress">
         <exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog" />
         <exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -33,6 +33,6 @@
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="5.3-"/>
+    <config name="testVersion" value="7.2-"/>
     <rule ref="PHPCompatibilityWP"/>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
 * Requires at least: 4.7
 * Tested up to:      6.3
-* Requires PHP:      5.3
+* Requires PHP:      7.2
 * Stable tag:        1.8.4
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 * Contributors:      pluginkollektiv
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              analytics, dashboard, pageviews, privacy, statistics, stats, visits, web stats, widget
-* Requires at least: 4.7
-* Tested up to:      6.3
+* Requires at least: 5.1
+* Tested up to:      6.5
 * Requires PHP:      7.2
 * Stable tag:        1.8.4
 * License:           GPLv3 or later

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,13 +11,19 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
-if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?";
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
+
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 
 // Give access to tests_add_filter() function.
-require_once $_tests_dir . '/includes/functions.php';
+require_once "{$_tests_dir}/includes/functions.php";
 
 /**
  * Manually load the plugin being tested.
@@ -29,7 +35,7 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
-require $_tests_dir . '/includes/bootstrap.php';
+require "{$_tests_dir}/includes/bootstrap.php";
 
 // Statify-specific test support.
 require_once __DIR__ . '/trait-statify-test-support.php';

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -24,6 +24,6 @@
 	</rule>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibility"/>
 </ruleset>

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -16,7 +16,7 @@
 	<file>tests</file>
 
 	<!-- WordPress coding standards -->
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="minimum_supported_wp_version" value="5.1"/>
 	<rule ref="WordPress">
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>


### PR DESCRIPTION
As discussed in #253 we already have some pending changes that require more recent PHP and WordPress versions.

Current requirements (up to 1.8.x):
* WordPress 4.7
* PHP 5.2

Minimum without reverting stuff would be PHP 5.3 (#247) and WP 5.1 (#252).

Maintaining and testing old stuff is time consuming and only very few sites actually have such requirements. With this change, we jump forward to:
* WordPress 5.1
* PHP 7.2

WP 5.1 does not play nice with PHPUnit 7/8 and neither with Polyfills, so let's just use 5.2 as minimum version in CI tests and rely on the static compatibility checks instead of investing time and effort in testing one more version.