### PR TITLE
introduce blueprint.json for plugin preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-admin/",
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "defineWpConfigConsts",
+      "consts": {
+        "IS_PLAYGROUND_PREVIEW": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add a _blueprint.json_ to run WordPress in Playground with _Statify_ installed.

Ref.: https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/