### PR TITLE
ci: add workflow to run wp plugin checks

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,7 @@
 /.wordpress-org
 /bin
 /coverage
+/dist
 /node_modules
 /tests
 /vendor

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,31 @@
+name: Plugin check
+on:
+  push:
+    branches: [ stable ]
+  pull_request:
+    branches: [ stable ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Install
+        run:  composer install --no-interaction
+
+      - name: Package plugin
+        run: |
+          mkdir -p ./dist
+          rsync -rc --exclude-from=.distignore ./ ./dist/statify --delete --delete-excluded
+
+      - name: Check WP plugin
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: ./dist/statify

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 composer.lock
 coverage
 css/*.min.css
+dist
 js/*.min.js
 js/*.min.js.map
 lib


### PR DESCRIPTION
Add a new workflow to run the **[plugin-check-action](https://github.com/WordPress/plugin-check-action)** when pushing or merging to _stable_.

We build the plugin first and re-use the .distignore file to generate the final plugin package. Otherwise we should run into several issues with files. This list is also used for deployment, so the results should be as representative as it gets.

----

Run on current _develop_ branch shows one error:

> Error: The Stable Tag in your readme file does not match the version in your main plugin file. Your Stable Tag is meant to be the stable version of your plugin, not of WordPress. For your plugin to be properly downloaded from WordPress.org, those values need to be the same. If they’re out of sync, your users won’t get the right version of your code.

That's correct and intentional on the _develop_ branch. Hence we should start running the full set of checks only before merging to _stable_.

and a few warnings
> Warning: One or more tags were ignored. Please limit your plugin to 5 tags.

(now fixed, see #293)

> Warning: Use of a direct database call is discouraged.
> Warning: Direct database call without caching detected. Consider using wp_cache_get() / wp_cache_set() or wp_cache_delete().

(already known from PHPCS)