### PR TITLE
Adjust parameters for compatibility with multisite hooks

### DIFF
--- a/inc/class-statify-install.php
+++ b/inc/class-statify-install.php
@@ -51,11 +51,11 @@ class Statify_Install {
 	 *
 	 * @since 1.4.4
 	 *
-	 * @param int $site_id Site ID.
+	 * @param WP_Site $new_site Site object.
 	 */
-	public static function init_site( int $site_id ): void {
+	public static function init_site( WP_Site $new_site ): void {
 
-		switch_to_blog( $site_id );
+		switch_to_blog( $new_site->site_id );
 
 		self::_apply();
 

--- a/inc/class-statify-uninstall.php
+++ b/inc/class-statify-uninstall.php
@@ -48,11 +48,11 @@ class Statify_Uninstall {
 	 *
 	 * @since 1.4.4
 	 *
-	 * @param int $site_id Site ID.
+	 * @param WP_Site $old_site Site object.
 	 */
-	public static function init_site( int $site_id ): void {
+	public static function init_site( WP_Site $old_site ): void {
 
-		switch_to_blog( $site_id );
+		switch_to_blog( $old_site->site_id );
 
 		self::_apply();
 


### PR DESCRIPTION
Hello!

This PR updates the multisite related functionality to use the `WP_Site` object instead of a site ID parameter, providing compatibility with the [wp_initialize_site](https://developer.wordpress.org/reference/hooks/wp_initialize_site/) and [wp_uninitialize_site](https://developer.wordpress.org/reference/hooks/wp_uninitialize_site/) hooks.

**Current behavior:** 
When the plugin is network-activated, creating a new site in the network causes a fatal error:

<img width="791" alt="Screenshot 2024-10-30 at 15 25 02" src="https://github.com/user-attachments/assets/a1edcb4f-f860-4246-87d2-1a0af28c0d9c">
