### PR TITLE
use add_action() instead of add_filter() for rest_api_init

### DIFF
--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -87,7 +87,7 @@ class Statify {
 				add_filter( 'amp_post_template_analytics', array( 'Statify_Frontend', 'amp_post_template_analytics' ) );
 			}
 			// Initialize REST API.
-			add_filter( 'rest_api_init', array( 'Statify_Api', 'init' ) );
+			add_action( 'rest_api_init', array( 'Statify_Api', 'init' ) );
 		}
 	}
 


### PR DESCRIPTION
The `rest_api_init` hook is an action hook and should be used as such. Replace `add_filter()` with `add_action()` to register our init method.

Fixes: 74b63c381f7f216a9956a3e299264e5c04a0191e