### PR TITLE
introduce PHPStan static code analysis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -24,6 +24,7 @@
 /package-lock.json
 /composer.lock
 /phpcs.xml
+/phpstan.neon
 /phpunit.xml
 /phpunit.coverage.xml
 /phpunit.report.xml

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@
 /composer.lock export-ignore
 /composer-php5.lock export-ignore
 /phpcs.xml export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml export-ignore
 /phpunit.coverage.xml export-ignore
 /phpunit.report.xml export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,18 @@
+name: PHPStan
+on: [push, pull_request]
+jobs:
+  run-phpstan:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          tools: composer
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-scripts
+      - name: PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,14 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^v1.1",
     "matthiasmullie/minify": "^1.3.75",
+    "phpcompatibility/phpcompatibility-wp": "^2.1",
+    "phpstan/extension-installer": "^1.4",
+    "phpstan/phpstan": "^1.12",
+    "phpunit/phpunit": "^7|^9",
     "slowprog/composer-copy-file": "^0.3",
     "squizlabs/php_codesniffer": "^3.13",
-    "phpcompatibility/phpcompatibility-wp": "^2.1",
+    "szepeviktor/phpstan-wordpress": "^v1.3",
     "wp-coding-standards/wpcs": "^3.2",
-    "phpunit/phpunit": "^7|^9",
     "yoast/phpunit-polyfills": "^1.1"
   },
   "repositories": [
@@ -74,6 +77,9 @@
       "minifyjs js/snippet.js > js/snippet.min.js",
       "minifycss vendor/npm-asset/chartist-plugin-tooltips-updated/dist/chartist-plugin-tooltip.css > css/chartist-plugin-tooltip.min.css"
     ],
+    "phpstan": [
+      "phpstan analyse --memory-limit=1G"
+    ],
     "test": [
       "phpunit"
     ],
@@ -91,7 +97,8 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+  level: 3
+  paths:
+    - inc/
+    - views/
+    - statify.php
+  ignoreErrors:
+    - '/^Constant STATIFY_BASE not found\.$/'


### PR DESCRIPTION
Add PHPStan and WP stubs to our dev-dependencies and configure a CI workflow to run the analysis.

We can start at level 3 without any additional code changes required.