### PR TITLE
remove redundant permissions check for dashboard control

### DIFF
--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -38,9 +38,6 @@ class Statify_Dashboard extends Statify {
 			return;
 		}
 
-		// Check if user can edit the widget.
-		$can_edit = self::user_can_see_stats();
-
 		// Load textdomain.
 		load_plugin_textdomain(
 			'statify',
@@ -56,7 +53,7 @@ class Statify_Dashboard extends Statify {
 			'statify_dashboard',
 			'Statify',
 			array( __CLASS__, 'print_frontview' ),
-			$can_edit ? array( __CLASS__, 'print_backview' ) : null
+			array( __CLASS__, 'print_backview' )
 		);
 
 		// Init CSS.


### PR DESCRIPTION
At the point where permissions are checked, `user_can_see_stats()` is always true, unless some special hook is with dynamic response behavior is configured.

https://github.com/pluginkollektiv/statify/blob/3924fcee573a75c4a53b4b876a0bf57b3ab7153b/inc/class-statify-dashboard.php#L37-L42

WordPress takes care of control access and the callback also contains a permissions check, so let's simply register both callbacks and omit the redundant check.

Fixes: a2b533009b9884d77051e53aca22d55ee3bebd22
Originally introduced as part of #111 (v1.7.0)