### PR TITLE
Add Reset Statistics Functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,10 +59,12 @@
       "@lint-css"
     ],
     "lint-css": [
-      "npx stylelint css/dashboard.css"
+      "npx stylelint css/dashboard.css",
+      "npx stylelint css/settings.css"
     ],
     "lint-js": [
       "npx eslint js/dashboard.js",
+      "npx eslint js/settings.js",
       "npx eslint js/snippet.js"
     ],
     "lint-php": [
@@ -73,7 +75,9 @@
     ],
     "minify": [
       "minifycss css/dashboard.css > css/dashboard.min.css",
+      "minifycss css/settings.css > css/settings.min.css",
       "minifyjs js/dashboard.js > js/dashboard.min.js",
+      "minifyjs js/settings.js > js/settings.min.js",
       "minifyjs js/snippet.js > js/snippet.min.js",
       "minifycss vendor/npm-asset/chartist-plugin-tooltips-updated/dist/chartist-plugin-tooltip.css > css/chartist-plugin-tooltip.min.css"
     ],

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,0 +1,34 @@
+/* Danger Zone Section */
+.statify-danger-zone {
+    border: 2px solid #dc3232;
+    padding: 15px;
+    background: #fff;
+    border-radius: 4px;
+    margin-top: 20px;
+}
+
+.statify-danger-zone h3 {
+    margin-top: 0;
+    color: #dc3232;
+    font-size: 1.1em;
+}
+
+.statify-danger-zone p {
+    margin-bottom: 10px;
+}
+
+.statify-danger-zone .button {
+    color: #dc3232;
+    border-color: #dc3232;
+}
+
+.statify-danger-zone .button:hover {
+    background: #dc3232;
+    color: #fff;
+    border-color: #dc3232;
+}
+
+.statify-danger-zone .button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,6 +1,6 @@
 /* Danger Zone Section */
 .statify-danger-zone {
-    border: 2px solid #dc3232;
+    border: 2px solid #d63638;
     padding: 15px;
     background: #fff;
     border-radius: 4px;
@@ -9,7 +9,7 @@
 
 .statify-danger-zone h3 {
     margin-top: 0;
-    color: #dc3232;
+    color: #b32d2e;
     font-size: 1.1em;
 }
 
@@ -18,17 +18,18 @@
 }
 
 .statify-danger-zone .button {
-    color: #dc3232;
-    border-color: #dc3232;
+    color: #d63638;
+    border-color: #b32d2e;
 }
 
-.statify-danger-zone .button:hover {
-    background: #dc3232;
+.statify-danger-zone .button:hover,
+.statify-danger-zone .button:focus {
+    background: #d63638;
+	border-color: #b32d2e;
+	box-shadow: 0 0 0 1px #b32d2e;
     color: #fff;
-    border-color: #dc3232;
 }
 
 .statify-danger-zone .button:disabled {
-    opacity: 0.6;
     cursor: not-allowed;
 }

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -25,6 +25,7 @@ class Statify_Api extends Statify {
 	const REST_NAMESPACE   = 'statify/v1';
 	const REST_ROUTE_TRACK = 'track';
 	const REST_ROUTE_STATS = 'stats';
+	const REST_ROUTE_RESET = 'reset';
 
 	/**
 	 * Initialize REST API routes.
@@ -52,6 +53,18 @@ class Statify_Api extends Statify {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_stats' ),
 				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_RESET,
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( __CLASS__, 'rest_reset_data' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
 			)
 		);
 
@@ -150,5 +163,34 @@ class Statify_Api extends Statify {
 		}
 
 		return new WP_REST_Response( $stats );
+	}
+
+	/**
+	 * REST API callback to reset statistics data.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public static function rest_reset_data( WP_REST_Request $request ) {
+		$result = Statify_Table::truncate();
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'reset_failed',
+				__( 'Failed to reset statistics data.', 'statify' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		delete_transient( 'statify_data' );
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'message' => __( 'Statistics data has been successfully reset.', 'statify' ),
+			),
+			200
+		);
 	}
 }

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -61,7 +61,7 @@ class Statify_Api extends Statify {
 			self::REST_ROUTE_RESET,
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( __CLASS__, 'rest_reset_data' ),
+				'callback'            => array( __CLASS__, 'reset_data' ),
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
@@ -172,7 +172,7 @@ class Statify_Api extends Statify {
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
 	 */
-	public static function rest_reset_data( WP_REST_Request $request ) {
+	public static function reset_data( WP_REST_Request $request ) {
 		$result = Statify_Table::truncate();
 
 		if ( ! $result ) {

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -24,6 +24,7 @@ class Statify_Settings {
 	 * @return void
 	 */
 	public static function register_settings(): void {
+		self::enqueue_settings_assets();
 		register_setting( 'statify', 'statify', array( __CLASS__, 'sanitize_options' ) );
 
 		// Global settings.
@@ -119,6 +120,14 @@ class Statify_Settings {
 			'statify',
 			'statify-skip',
 			array( 'label_for' => 'statify-skip-logged_in' )
+		);
+
+		// Reset statistic.
+		add_settings_section(
+			'statify-reset',
+			__( 'Reset Statistics', 'statify' ),
+			array( __CLASS__, 'reset_data_section' ),
+			'statify'
 		);
 	}
 
@@ -347,6 +356,31 @@ class Statify_Settings {
 	}
 
 	/**
+	 * Section for reset statistics functionality.
+	 *
+	 * @return void
+	 */
+	public static function reset_data_section(): void {
+		?>
+		<div class="statify-danger-zone">
+			<h3>
+				<?php esc_html_e( '⚠️ Danger Zone', 'statify' ); ?>
+			</h3>
+			<p>
+				<?php esc_html_e( 'Permanently delete all statistics data. This action cannot be undone!', 'statify' ); ?>
+			</p>
+			<p>
+				<button type="button"
+						id="statify-reset-data"
+						class="button button-secondary">
+					<?php esc_html_e( 'Reset All Statistics', 'statify' ); ?>
+				</button>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Action to be triggered after Statify options have been saved.
 	 * Delete transient data to refresh the dashboard widget and flushes Cachify cache, if the plugin is available and
 	 * JS settings have changed.
@@ -482,5 +516,28 @@ class Statify_Settings {
 		</div>
 
 		<?php
+	}
+
+	/**
+	 * Enqueues settings assets.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_settings_assets(): void {
+		wp_enqueue_style(
+			'statify-settings',
+			plugins_url( 'css/settings.css', STATIFY_FILE ),
+			array(),
+			STATIFY_VERSION
+		);
+
+		// Enqueue settings JavaScript.
+		wp_enqueue_script(
+			'statify-settings-js',
+			plugins_url( 'js/settings.js', STATIFY_FILE ),
+			array( 'wp-api-fetch', 'wp-i18n' ),
+			STATIFY_VERSION,
+			true
+		);
 	}
 }

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -533,7 +533,7 @@ class Statify_Settings {
 
 		// Enqueue settings JavaScript.
 		wp_enqueue_script(
-			'statify-settings-js',
+			'statify-settings',
 			plugins_url( 'js/settings.js', STATIFY_FILE ),
 			array( 'wp-api-fetch', 'wp-i18n' ),
 			STATIFY_VERSION,

--- a/inc/class-statify-table.php
+++ b/inc/class-statify-table.php
@@ -87,4 +87,17 @@ class Statify_Table {
 		// Remove.
 		$wpdb->query( "DROP TABLE IF EXISTS `$wpdb->statify`" );
 	}
+
+	/**
+	 * Clear Statify table.
+	 *
+	 * @since   2.0.0
+	 * @version 2.0.0
+	 */
+	public static function truncate(): bool {
+
+		global $wpdb;
+
+		return (bool) $wpdb->query( "TRUNCATE TABLE `$wpdb->statify`" );
+	}
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,52 @@
+(function () {
+	'use strict';
+
+	function initResetButton() {
+		const resetButton = document.getElementById('statify-reset-data');
+
+		if (!resetButton) {
+			return;
+		}
+
+		resetButton.addEventListener('click', (e) => {
+			e.preventDefault();
+
+			if (
+				// eslint-disable-next-line no-alert
+				!confirm(
+					wp.i18n.__(
+						'Are you sure you want to delete all statistics data? This action cannot be undone!',
+						'statify'
+					)
+				)
+			) {
+				return;
+			}
+
+			const button = this;
+			const originalText = button.textContent;
+
+			button.disabled = true;
+			button.textContent = wp.i18n.__('Resetting…', 'statify');
+
+			wp.apiFetch({
+				path: '/statify/v1/reset',
+				method: 'POST',
+			})
+				.then((data) => {
+					// eslint-disable-next-line no-alert
+					alert(data.message);
+					button.textContent = originalText;
+					button.disabled = false;
+				})
+				.catch((error) => {
+					// eslint-disable-next-line no-alert
+					alert(wp.i18n.__('Error:', 'statify') + error.message);
+					button.disabled = false;
+					button.textContent = originalText;
+				});
+		});
+	}
+
+	document.addEventListener('DOMContentLoaded', initResetButton);
+})();


### PR DESCRIPTION
Hey! 👋

This PR adds a long-requested feature - the ability to reset/delete all statistics data directly from the settings page.

### What's new?

- **Danger Zone section** on the settings page with a red "Reset All Statistics" button
- Clicking it shows a confirmation dialog (because we don't want accidents!)
- Uses the REST API (`/statify/v1/reset`)
- Truncates the stats table and resets auto-increment counters
- Clears the transient cache so the dashboard updates properly

<img width="1352" height="229" alt="image" src="https://github.com/user-attachments/assets/12b4d7b9-a166-4a80-bc29-c90a35caf1f6" />


Closes https://github.com/pluginkollektiv/statify/issues/262.