### PR TITLE
use WP admin theme colors for dashboard charts if available

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -24,22 +24,22 @@ body.rtl .statify-chart * {
 }
 
 .statify-chart .ct-line {
-	stroke: #3582c4;
+	stroke: var(--wp-admin-theme-color-darker-10, #3582c4);
 	stroke-width: 2px;
 }
 
 .statify-chart .ct-point {
 	fill: #fff;
-	stroke: #3582c4;
+	stroke: var(--wp-admin-theme-color-darker-10, #3582c4);
 	stroke-width: 1.5px;
 }
 
 .statify-chart .ct-area {
-	fill: #3582c4;
+	fill: var(--wp-admin-theme-color, #3582c4);
 }
 
 .statify-chart .ct-bar {
-	stroke: #3582c4;
+	stroke: var(--wp-admin-theme-color-darker-10, #3582c4);
 }
 
 .statify-chart .ct-label.ct-horizontal.ct-end {
@@ -66,7 +66,7 @@ body.rtl .statify-chart * {
 }
 
 .statify-chartist-tooltip .chartist-tooltip-meta {
-	color: #3582c4;
+	color: var(--wp-admin-theme-color-darker-20, #3582c4);
 }
 
 


### PR DESCRIPTION
Noticed on a WP 7.0 beta site where the "Modern" theme is now default that our current blue does not really fit the dashboard theme. But this "issue" is rather old actually, because a user could have selected a non-default theme for years.

Theme color variables should be available since WP 5.7, so we should probably use them with fallback to our current values, if not available.

<details><summary>current (fixed) colors</summary>
<img width="537" height="391" alt="statify_312_current" src="https://github.com/user-attachments/assets/bc1ae95e-6ce4-4c99-b803-73f0d86f6838" />
</details>

<details><summary>preview with all 9 themes</summary>
<br>
<p>Modern (default in 7.x)</p>
<img width="537" height="391" alt="statify_312_modern" src="https://github.com/user-attachments/assets/e606b277-8aa0-45a6-a28b-1e47f3f0c7fb" />

<p>Fresh (default in 6.x)</p>
<img width="537" height="391" alt="statify_312_fresh" src="https://github.com/user-attachments/assets/95a771c2-3784-4827-83d8-e68dc78f9413" />

<p>Light</p>
<img width="537" height="391" alt="statify_312_light" src="https://github.com/user-attachments/assets/9690e9b8-710c-4109-9de0-43deab4f4cc0" />

<p>Blue</p>
<img width="537" height="391" alt="statify_312_blue" src="https://github.com/user-attachments/assets/cfa057ca-4041-4064-9e7f-47e7d285d78e" />

<p>Coffee</p>
<img width="537" height="391" alt="statify_312_coffee" src="https://github.com/user-attachments/assets/19108885-29b3-4767-b918-f4a27eb291e5" />

<p>Ectoplasm</p>
<img width="537" height="391" alt="statify_312_ectoplasm" src="https://github.com/user-attachments/assets/36b91c4e-da14-4ee2-b10b-e296e576ac4d" />

<p>Midnight</p>
<img width="537" height="391" alt="statify_312_midnight" src="https://github.com/user-attachments/assets/990d3443-8923-4ccd-b94e-783737949fa3" />

<p>Ocean</p>
<img width="537" height="391" alt="statify_312_ocean" src="https://github.com/user-attachments/assets/7b3f4ba7-c52c-4281-9a7d-a65cb1e567e3" />

<p>Sunrise</p>
<img width="537" height="391" alt="statify_312_sunrise" src="https://github.com/user-attachments/assets/37d66a0e-6e67-4a40-8a49-2e237da269da" />
</details>
