### PR TITLE
fix: fill gaps in dashboard data (#313)

### DIFF
--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -167,11 +167,8 @@ class Statify_Dashboard extends Statify {
 		// Get from DB.
 		$data = self::select_data();
 
-		// Prepare data.
+		// Store in cache.
 		if ( ! empty( $data['visits'] ) ) {
-			$data['visits'] = array_reverse( $data['visits'] );
-
-			// Make cache.
 			set_transient(
 				'statify_data',
 				$data,
@@ -205,12 +202,15 @@ class Statify_Dashboard extends Statify {
 		$current_date = current_time( 'Y-m-d' );
 
 		$data = array(
-			'visits'   => $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT `created` as `date`, COUNT(`created`) as `count` FROM `$wpdb->statify` GROUP BY `created` ORDER BY `created` DESC LIMIT %d",
-					$days_show
+			'visits'   => self::fill_gaps(
+				$wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT `created` as `date`, COUNT(*) as `count` FROM `$wpdb->statify` WHERE `created` BETWEEN CURDATE() - INTERVAL %d DAY AND CURDATE() GROUP BY `created` ORDER BY `created` ASC",
+						$days_show - 1
+					),
+					ARRAY_A
 				),
-				ARRAY_A
+				$days_show
 			),
 		);
 
@@ -268,5 +268,40 @@ class Statify_Dashboard extends Statify {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Fill gaps in statistics data array.
+	 * We only fill gaps inbeteen datapoints and between the latest datapoint and "today".
+	 *
+	 * @param array $data {
+	 *     Data from database.
+	 *
+	 *     @type string $date  The date (Y-m-d).
+	 *     @type int    $count Count.
+	 * }
+	 * @param int   $days Number of days to show.
+	 * @return array Array with filled gaps.
+	 */
+	private static function fill_gaps( array $data, int $days ): array {
+		if ( empty( $data ) || count( $data ) == $days ) {
+			return $data;
+		}
+
+		$result = array();
+		$lookup = array_column( $data, 'count', 'date' );
+		$append = false;
+		for ( $i = $days - 1; $i >= 0; $i-- ) {
+			$date = ( new DateTime( "-$i days" ) )->format( 'Y-m-d' );
+			if ( $append || isset( $lookup[ $date ] ) ) {
+				$append   = true;
+				$result[] = array(
+					'date'  => $date,
+					'count' => intval( $lookup[ $date ] ?? 0 ),
+				);
+			}
+		}
+
+		return $result;
 	}
 }

--- a/tests/test-dashboard.php
+++ b/tests/test-dashboard.php
@@ -152,6 +152,8 @@ class Test_Dashboard extends WP_UnitTestCase {
 		$date1 = new DateTime();
 		$date2 = ( new DateTime() )->modify( '-1 days' );
 		$date3 = ( new DateTime() )->modify( '-2 days' );
+		$date4 = ( new DateTime() )->modify( '-3 days' );
+		$date5 = ( new DateTime() )->modify( '-4 days' );
 
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://statify.pluginkollektiv.org/', '/', 3 );
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://statify.pluginkollektiv.org/', '/test/', 4 );
@@ -164,22 +166,29 @@ class Test_Dashboard extends WP_UnitTestCase {
 		$this->insert_test_data( $date3->format( 'Y-m-d' ), 'https://pluginkollektiv.org/', '', 2 );
 		$this->insert_test_data( $date3->format( 'Y-m-d' ), '', '/', 1 );
 
+		$this->insert_test_data( $date5->format( 'Y-m-d' ), '', '/test/', 1 );
+
 		// Initialize with default configuration, all limits greater data dimension.
 		Statify::init();
 		$this->init_statify_widget( 14, 14, 3, false, false );
 		$stats = $this->get_stats();
 
-		$this->assertEquals( 3, count( $stats['visits'] ), 'Unexpected number of days with visits' );
-		$this->assertEquals( $date3->format( 'Y-m-d' ), $stats['visits'][0]['date'], 'Unexpected date of tracking 2 days ago' );
-		$this->assertEquals( 3, $stats['visits'][0]['count'], 'Unexpected number of visits 2 days ago' );
-		$this->assertEquals( $date2->format( 'Y-m-d' ), $stats['visits'][1]['date'], 'Unexpected date of tracking yesterday' );
-		$this->assertEquals( 4, $stats['visits'][1]['count'], 'Unexpected number of visits yesterday' );
-		$this->assertEquals( $date1->format( 'Y-m-d' ), $stats['visits'][2]['date'], 'Unexpected date of tracking today' );
-		$this->assertEquals( 8, $stats['visits'][2]['count'], 'Unexpected number of visits today' );
+		$this->assertEquals( 5, count( $stats['visits'] ), 'Unexpected number of days with visits' );
+
+		$this->assertEquals( $date5->format( 'Y-m-d' ), $stats['visits'][0]['date'], 'Unexpected date of tracking 4 days ago' );
+		$this->assertEquals( 1, $stats['visits'][0]['count'], 'Unexpected number of visits 4 days ago' );
+		$this->assertEquals( $date4->format( 'Y-m-d' ), $stats['visits'][1]['date'], 'Unexpected date of tracking 3 days ago' );
+		$this->assertEquals( 0, $stats['visits'][1]['count'], 'Unexpected number of visits 3 days ago' );
+		$this->assertEquals( $date3->format( 'Y-m-d' ), $stats['visits'][2]['date'], 'Unexpected date of tracking 2 days ago' );
+		$this->assertEquals( 3, $stats['visits'][2]['count'], 'Unexpected number of visits 2 days ago' );
+		$this->assertEquals( $date2->format( 'Y-m-d' ), $stats['visits'][3]['date'], 'Unexpected date of tracking yesterday' );
+		$this->assertEquals( 4, $stats['visits'][3]['count'], 'Unexpected number of visits yesterday' );
+		$this->assertEquals( $date1->format( 'Y-m-d' ), $stats['visits'][4]['date'], 'Unexpected date of tracking today' );
+		$this->assertEquals( 8, $stats['visits'][4]['count'], 'Unexpected number of visits today' );
 
 		$this->assertEquals( 3, count( $stats['target'] ), 'Unexpected number of top targets' );
 		$this->assertEquals( '/test/', $stats['target'][0]['url'], 'Unexpected 1st target path' );
-		$this->assertEquals( 6, $stats['target'][0]['count'], 'Unexpected 1st target count' );
+		$this->assertEquals( 7, $stats['target'][0]['count'], 'Unexpected 1st target count' );
 		$this->assertEquals( '/', $stats['target'][1]['url'], 'Unexpected 2nd target path' );
 		$this->assertEquals( 5, $stats['target'][1]['count'], 'Unexpected 2nd target count' );
 		$this->assertEquals( '', $stats['target'][2]['url'], 'Unexpected 3rd target path' );
@@ -232,7 +241,7 @@ class Test_Dashboard extends WP_UnitTestCase {
 		$stats3 = $this->get_stats();
 
 		$this->assertEquals(
-			array_slice( $stats['visits'], 1 ),
+			array_slice( $stats['visits'], 3 ),
 			$stats3['visits'],
 			'Stats for 2 days should be equal to the slice of complete data'
 		);
@@ -263,8 +272,8 @@ class Test_Dashboard extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'visit_totals', $stats3, 'Totals should be provided, if configured' );
 		$this->assertEquals( 8, $stats3['visit_totals']['today'], 'Unexpected total for today' );
-		$this->assertEquals( 15, $stats3['visit_totals']['since_beginning']['count'], 'Unexpected total since beginning' );
-		$this->assertEquals( $date3->format( 'Y-m-d' ), $stats3['visit_totals']['since_beginning']['date'], 'Unexpected first date' );
+		$this->assertEquals( 16, $stats3['visit_totals']['since_beginning']['count'], 'Unexpected total since beginning' );
+		$this->assertEquals( $date5->format( 'Y-m-d' ), $stats3['visit_totals']['since_beginning']['date'], 'Unexpected first date' );
 
 		// Finally we add another entry in the database, but utilize the transient cache (4min should be enough for the test case).
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://example.com/', '/example/', 1 );
@@ -275,7 +284,7 @@ class Test_Dashboard extends WP_UnitTestCase {
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://example.com/', '/', 1 );
 		$this->insert_test_data( $date1->format( 'Y-m-d' ), 'https://example.net/', '/', 1 );
 		$stats5 = Statify_Dashboard::get_stats( true );
-		$this->assertEquals( 18, $stats5['visit_totals']['since_beginning']['count'], 'Unexpected total since beginning' );
+		$this->assertEquals( 19, $stats5['visit_totals']['since_beginning']['count'], 'Unexpected total since beginning' );
 		$this->assertEquals( 2, $stats5['referrer'][1]['count'], 'Unexpected 2nd referrer count' );
 		$this->assertEquals( 'example.com', $stats5['referrer'][1]['host'], 'Unexpected 2nd referrer hostname' );
 		$this->assertEquals( 2, $stats5['referrer'][2]['count'], 'Unexpected 3rd referrer count' );


### PR DESCRIPTION
Fetch data for the last N days instead of the last N available entries and fill gaps between two data points with zeros. Also fill up potential gaps between the latest entry and today.

With the explicit date range we can now change the sorting in the SQL statement directly and omit reversing the array afterward.

resolves #313

----

before:
```json
[
  {"date":"2026-04-07","count":1},
  {"date":"2026-04-09","count":3},
  {"date":"2026-04-10","count":4},
  {"date":"2026-04-11","count":8},
]
```

after:
```json
[
  {"date":"2026-04-07","count":1},
  {"date":"2026-04-08","count":0},
  {"date":"2026-04-09","count":3},
  {"date":"2026-04-10","count":4},
  {"date":"2026-04-11","count":8}
]
```

And on the test site from the issue:
<img width="393" height="191" alt="Image" src="https://github.com/user-attachments/assets/db7baa92-bea0-47a1-b747-7d421783b620" /> <img width="393" height="191" alt="statify_314" src="https://github.com/user-attachments/assets/42e49b12-23b6-4ca9-ad12-3946e84d025d" />
