### PR TITLE
update Chartist tooltips plugin

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -363,10 +363,13 @@
 					offset: 30,
 				},
 				plugins: [
-					Chartist.plugins.tooltip({
-						appendToBody: true,
-						class: 'statify-chartist-tooltip',
-					}),
+					[
+						ChartistPluginTooltip,
+						{
+							appendToBody: true,
+							class: 'statify-chartist-tooltip',
+						},
+					],
 				],
 			}
 		);
@@ -460,18 +463,26 @@
 					onlyInteger: true,
 				},
 				plugins: [
-					Chartist.plugins.tooltip({
-						appendToBody: true,
-						anchorToPoint: true,
-						class: 'statify-chartist-tooltip',
-						transformTooltipTextFnc(y) {
-							return wp.i18n.sprintf(
-								/* translators: %s: Number of page views. */
-								wp.i18n._n('%s view', '%s views', y, 'statify'),
-								y
-							);
+					[
+						ChartistPluginTooltip,
+						{
+							appendToBody: true,
+							anchorToPoint: true,
+							class: 'statify-chartist-tooltip',
+							transformTooltipTextFnc(y) {
+								return wp.i18n.sprintf(
+									/* translators: %s: Number of page views. */
+									wp.i18n._n(
+										'%s view',
+										'%s views',
+										y,
+										'statify'
+									),
+									y
+								);
+							},
 						},
-					}),
+					],
 				],
 			}
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "chartist": "^1.5.0",
-        "chartist-plugin-tooltips-updated": "^1.0.0"
+        "@stklcode/chartist-plugin-tooltips": "^2.0.0",
+        "chartist": "^1.5.0"
       },
       "devDependencies": {
         "@wordpress/eslint-plugin": "^25.0.0",
@@ -3010,6 +3010,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/@stklcode/chartist-plugin-tooltips": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stklcode/chartist-plugin-tooltips/-/chartist-plugin-tooltips-2.0.0.tgz",
+      "integrity": "sha512-D/F7JNhaKPR4P9gFlEd1cMsTuZ+vIE6yJzKn/ngajfmFsIvVM45rTNw+b7jY0542P4clHRoFA3Nn1b/c064k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "chartist": "^1.0.0"
+      }
+    },
     "node_modules/@stylistic/stylelint-plugin": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.3.tgz",
@@ -4872,16 +4881,6 @@
       "license": "MIT OR WTFPL",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/chartist-plugin-tooltips-updated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chartist-plugin-tooltips-updated/-/chartist-plugin-tooltips-updated-1.0.0.tgz",
-      "integrity": "sha512-tBbfOzpBq4NuPB2L1AoSl55tgj2Nte7XLwDbqwmK7+be+KyrWY19rJAnigx8skVtKE7N5709wB9TYLylWZzjbQ==",
-      "deprecated": "This package is deprecated and will no longer receive updates, including bug fixes or new features. If you require tooltips, I recommend switching to another charting library.",
-      "license": "MIT",
-      "dependencies": {
-        "chartist": "^1.0.0"
       }
     },
     "node_modules/clean-stack": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "dependencies": {
     "chartist": "^1.5.0",
-    "chartist-plugin-tooltips-updated": "^1.0.0"
+    "@stklcode/chartist-plugin-tooltips": "^2.0.0"
   },
   "devDependencies": {
     "@wordpress/eslint-plugin": "^25.0.0",
@@ -18,7 +18,7 @@
     "build": "npm run copy-assets && npm run minify",
     "copy-assets": "vendor-copy",
     "minify": "npm run minify:js && npm run minify:css",
-    "minify:css": "esbuild css/dashboard.css css/settings.css node_modules/chartist-plugin-tooltips-updated/dist/chartist-plugin-tooltip.css --minify --outdir=css --outbase=. --entry-names=[name].min",
+    "minify:css": "esbuild css/dashboard.css css/settings.css --minify --outdir=css --outbase=. --entry-names=[name].min",
     "minify:js": "esbuild js/dashboard.js js/settings.js js/snippet.js --minify --outdir=js --outbase=js --entry-names=[name].min",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-css": "stylelint css/dashboard.css css/settings.css",
@@ -35,7 +35,11 @@
       "to": "js/chartist.min.js"
     },
     {
-      "from": "node_modules/chartist-plugin-tooltips-updated/dist/chartist-plugin-tooltip.min.js",
+      "from": "node_modules/@stklcode/chartist-plugin-tooltips/dist/chartist-plugin-tooltip.css",
+      "to": "css/chartist-plugin-tooltip.min.css"
+    },
+    {
+      "from": "node_modules/@stklcode/chartist-plugin-tooltips/dist/chartist-plugin-tooltip.umd.js",
       "to": "js/chartist-plugin-tooltip.min.js"
     }
   ]


### PR DESCRIPTION
The "updated" fork v1.0.0 is no longer maintained. Switch to a new fork without user-facing changes to keep thing running.

Note that I am the author of this fork [@stklcode/chartist-plugin-tooltip](https://github.com/stklcode/chartist-plugin-tooltip). The project was migrated to TypeScript and has received some minor adjustments for better integration into _Chartist_ v1, but no real change in functionality.