### PR TITLE
fix refresh button layout with long referrers or targets (#318)

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -130,7 +130,8 @@ body.rtl .statify-chart * {
 	flex: 1 0 50%;
 }
 
-#statify_dashboard .table.total {
+#statify_dashboard .table.total,
+#statify_dashboard .controls  {
 	flex: 0 0 100%;
 }
 
@@ -146,9 +147,10 @@ body.rtl .statify-chart * {
 }
 
 #statify_dashboard td.b {
-	text-align: right;
-	padding-right: 4px;
 	color: #646970;
+	padding-right: 4px;
+	text-align: right;
+	vertical-align: top;
 }
 
 #statify_dashboard label {

--- a/views/widget-front.php
+++ b/views/widget-front.php
@@ -55,4 +55,6 @@ $show_totals = (int) Statify::$options['show_totals'];
 	</div>
 <?php endif; ?>
 
-	<button type="button" class="button button-primary" id="statify_refresh"><?php esc_html_e( 'Refresh', 'statify' ); ?></button>
+	<div class="controls">
+		<button type="button" class="button button-primary" id="statify_refresh"><?php esc_html_e( 'Refresh', 'statify' ); ?></button>
+	</div>


### PR DESCRIPTION
In the dashboard widget, longer texts may cause the side-by-side tables to wrap. If no totals are displayed, the "refresh" button might be stretched to a side-column.

Wrap the button to enforce the standalone position at the bottom of the widget.

----

resolves #318