### PR TITLE
localize dates in JavaScript (#324)

### DIFF
--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -186,7 +186,7 @@ class Statify_Api extends Statify {
 		$visits          = $stats['visits'];
 		$stats['visits'] = array();
 		foreach ( $visits as $v ) {
-			$stats['visits'][ Statify::parse_date( $v['date'] ) ] = intval( $v['count'] );
+			$stats['visits'][ $v['date'] ] = intval( $v['count'] );
 		}
 
 		foreach ( $stats['referrer'] as &$r ) {
@@ -201,7 +201,7 @@ class Statify_Api extends Statify {
 			$stats['totals'] = array(
 				'today'   => intval( $stats['visit_totals']['today'] ),
 				'alltime' => intval( $stats['visit_totals']['since_beginning']['count'] ),
-				'since'   => Statify::parse_date( $stats['visit_totals']['since_beginning']['date'] ),
+				'since'   => $stats['visit_totals']['since_beginning']['date'],
 			);
 			unset( $stats['visit_totals'] );
 		}

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -270,15 +270,7 @@ class Statify {
 			'statify_chart_js',
 			'statifyDashboard',
 			array(
-				'i18n'  => array(
-					'sitename' => sanitize_key( get_bloginfo( 'name' ) ),
-					'months'   => array_map(
-						function ( $m ) {
-							return date_i18n( 'M', strtotime( '0000-' . $m . '-01' ) );
-						},
-						range( 1, 12 )
-					),
-				),
+				'sitename' => sanitize_key( get_bloginfo( 'name' ) ),
 			)
 		);
 	}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -149,7 +149,9 @@
 				const labels = Object.keys(data.visits);
 				const values = Object.values(data.visits);
 
-				render(charts.dashboard, labels, values, false);
+				render(charts.dashboard, labels, values, false, (date) =>
+					dateFormatYMD.format(new Date(date))
+				);
 
 				// Render top lists.
 				if (tables.referrer) {
@@ -257,6 +259,7 @@
 			labels,
 			values,
 			true,
+			(date) => dateFormatYMD.format(new Date(date)),
 			(day) => {
 				const date = new Date(day);
 				const mon = date.getMonth();
@@ -265,8 +268,7 @@
 				}
 				usedLabels.add(mon);
 				return dateFormatM.format(date);
-			},
-			(date) => dateFormatYMD.format(new Date(date))
+			}
 		);
 	}
 
@@ -322,7 +324,7 @@
 			);
 		}
 
-		render(root, labels, values, true, labelFunc, metaFunc);
+		render(root, labels, values, true, metaFunc, labelFunc);
 	}
 
 	/**
@@ -347,16 +349,16 @@
 	 * @param {string[]}                labels                Labels.
 	 * @param {number[]}                values                Values.
 	 * @param {boolean}                 showAxis              Show X axis? (default: true)
-	 * @param {function(string):string} labelInterpolationFnc Label interpolation function. (optional)
 	 * @param {function(string):string} labelToMetaFunc       Meta data (tooltip label) function. (optional)
+	 * @param {function(string):string} labelInterpolationFnc Label interpolation function. (optional)
 	 */
 	function render(
 		root,
 		labels,
 		values,
 		showAxis = true,
-		labelInterpolationFnc = (l) => l,
-		labelToMetaFunc = (l) => l
+		labelToMetaFunc = (l) => l,
+		labelInterpolationFnc = (l) => l
 	) {
 		// Remove the loading content or existing chart.
 		root.innerHTML = '';
@@ -595,7 +597,7 @@
 		col.innerText = wp.i18n.sprintf(
 			/* translators: %s: Date. */
 			wp.i18n.__('since %s', 'statify'),
-			data.since
+			dateFormatYMD.format(new Date(data.since))
 		);
 		rowAll.appendChild(col);
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -37,13 +37,23 @@
 	};
 
 	// Initialize number format.
-	const numberFormat = new Intl.NumberFormat(
-		wp.i18n.getLocaleData()['']?.lang || 'en'
-	);
-	const numberFormatPercent = new Intl.NumberFormat(
-		wp.i18n.getLocaleData()['']?.lang || 'en',
-		{ style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 }
-	);
+	const lang = wp.i18n.getLocaleData()['']?.lang || 'en';
+	const numberFormat = new Intl.NumberFormat(lang);
+	const numberFormatPercent = new Intl.NumberFormat(lang, {
+		style: 'percent',
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	});
+	const dateFormatYMD = new Intl.DateTimeFormat(lang, {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	});
+	const dateFormatYM = new Intl.DateTimeFormat(lang, {
+		year: 'numeric',
+		month: 'short',
+	});
+	const dateFormatM = new Intl.DateTimeFormat(lang, { month: 'short' });
 
 	/* ------------------------------------------------------------------ */
 
@@ -242,14 +252,22 @@
 		const values = Object.values(data);
 		const usedLabels = new Set();
 
-		render(root, labels, values, true, (day) => {
-			const mon = new Date(day).getMonth();
-			if (usedLabels.has(mon)) {
-				return '';
-			}
-			usedLabels.add(mon);
-			return statifyDashboard.i18n.months[mon];
-		});
+		render(
+			root,
+			labels,
+			values,
+			true,
+			(day) => {
+				const date = new Date(day);
+				const mon = date.getMonth();
+				if (usedLabels.has(mon)) {
+					return '';
+				}
+				usedLabels.add(mon);
+				return dateFormatM.format(date);
+			},
+			(date) => dateFormatYMD.format(new Date(date))
+		);
 	}
 
 	/**
@@ -265,30 +283,46 @@
 		);
 
 		let labelFunc = (l) => l;
-		let labels;
-		if (showYear && Object.keys(data.visits).length > 2) {
-			labels = Object.keys(data.visits).flatMap((y) =>
-				Object.keys(data.visits[y]).map((m) => `${y}-${m}-01`)
-			);
-			labelFunc = (date) => {
-				const d = new Date(date);
-				const m = d.getMonth();
-				if (m === 0) {
-					return String(d.getFullYear());
-				}
-				return '';
-			};
+		let metaFunc = (l) => l;
+		let labels = Object.keys(data.visits);
+		if (showYear) {
+			if (labels.length > 2) {
+				labels = labels.flatMap((y) =>
+					Object.keys(data.visits[y]).map(
+						(m) => `${y}-${m.padStart(2, '0')}-01`
+					)
+				);
+				/**
+				 * Interpolate labels by year if we show more than 2 years.
+				 *
+				 * @param {string} date Date string
+				 * @return {string} Year string
+				 */
+				labelFunc = (date) => {
+					const d = new Date(date);
+					const m = d.getMonth();
+					if (m === 0) {
+						return String(d.getFullYear());
+					}
+					return '';
+				};
+				metaFunc = (date) => dateFormatYM.format(new Date(date));
+			} else {
+				labels = labels.flatMap((y) =>
+					Object.keys(data.visits[y]).map((m) =>
+						dateFormatYM.format(new Date(y, m))
+					)
+				);
+			}
 		} else {
-			labels = Object.keys(data.visits).flatMap((y) =>
-				Object.keys(data.visits[y]).map(
-					(m) =>
-						statifyDashboard.i18n.months[m - 1] +
-						(showYear ? ' ' + y : '')
+			labels = labels.flatMap((y) =>
+				Object.keys(data.visits[y]).map((m) =>
+					dateFormatM.format(new Date(y, m - 1))
 				)
 			);
 		}
 
-		render(root, labels, values, true, labelFunc);
+		render(root, labels, values, true, labelFunc, metaFunc);
 	}
 
 	/**
@@ -314,13 +348,15 @@
 	 * @param {number[]}                values                Values.
 	 * @param {boolean}                 showAxis              Show X axis? (default: true)
 	 * @param {function(string):string} labelInterpolationFnc Label interpolation function. (optional)
+	 * @param {function(string):string} labelToMetaFunc       Meta data (tooltip label) function. (optional)
 	 */
 	function render(
 		root,
 		labels,
 		values,
 		showAxis = true,
-		labelInterpolationFnc = (l) => l
+		labelInterpolationFnc = (l) => l,
+		labelToMetaFunc = (l) => l
 	) {
 		// Remove the loading content or existing chart.
 		root.innerHTML = '';
@@ -409,7 +445,7 @@
 							),
 							numberFormat.format(d.value.y)
 						),
-						'ct:meta': labels[d.index],
+						'ct:meta': labelToMetaFunc(labels[d.index]),
 					},
 					'ct-point'
 				);
@@ -843,7 +879,7 @@
 
 		// Generate filename from table caption.
 		exportBtn.download =
-			statifyDashboard.i18n.sitename +
+			statifyDashboard.sitename +
 			'-' +
 			table.caption.innerText.replaceAll(/\s+/g, '_') +
 			'-export-' +


### PR DESCRIPTION
We have a mix of pre-formatted dates, ISO strings, month/year concatenation, month names and year numbers. Localize dates the same way we localize number formats in frontend using JS Intl helpers.

We can now remove the month names from localize_script and omit the i18n block of the statifyDashboard variable.

We may lose a custom configured date format if we use the same logic for the dashboard widget, but this way we render all dates the same way and always serve ISO date strings via API which make it little more useful.

----

resolves #324