### PR TITLE
minor corrections and improvements in dashboard script

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -557,12 +557,16 @@
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('t');
-			const link = document.createElement('A');
-			link.href = r.url;
-			link.target = '_blank';
-			link.rel = 'noopener noreferrer';
-			link.textContent = r.host || r.url;
-			col.appendChild(link);
+			if (/^https?:\/\//i.test(r.url)) {
+				const link = document.createElement('A');
+				link.href = r.url;
+				link.target = '_blank';
+				link.rel = 'noopener noreferrer';
+				link.textContent = r.host || r.url;
+				col.appendChild(link);
+			} else {
+				col.textContent = r.host || r.url;
+			}
 			row.appendChild(col);
 			return row;
 		});

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -629,16 +629,22 @@
 
 			for (let month = 1; month <= 12; month++) {
 				col = document.createElement('TD');
-				col.textContent =
-					month in data.visits[year]
-						? numberFormat.format(data.visits[year][month])
-						: '-';
+				if (month in data.visits[year]) {
+					col.dataset.raw = String(data.visits[year][month]);
+					col.textContent = numberFormat.format(
+						data.visits[year][month]
+					);
+				} else {
+					col.dataset.raw = '';
+					col.textContent = '-';
+				}
 				row.appendChild(col);
 				sum += data.visits[year][month] || 0;
 			}
 
 			col = document.createElement('TD');
 			col.classList.add('statify-table-sum');
+			col.dataset.raw = String(sum);
 			col.textContent = numberFormat.format(sum);
 			row.appendChild(col);
 
@@ -671,6 +677,7 @@
 			++vls[m];
 			min[m] = Math.min(min[m], count);
 			max[m] = Math.max(max[m], count);
+			out[d.getDate() - 1][m].dataset.raw = String(count);
 			out[d.getDate() - 1][m].textContent = numberFormat.format(count);
 		}
 
@@ -688,12 +695,16 @@
 			];
 		for (const [m, s] of sum.entries()) {
 			if (vls[m] > 0) {
+				out[m].dataset.raw = String(s);
 				out[m].textContent = numberFormat.format(s);
+				avg[m].dataset.raw = String(Math.round(s / vls[m]));
 				avg[m].textContent = numberFormat.format(
 					Math.round(s / vls[m])
 				);
 			} else {
+				out[m].dataset.raw = '';
 				out[m].textContent = '-';
+				avg[m].dataset.raw = '';
 				avg[m].textContent = '-';
 			}
 		}
@@ -705,6 +716,7 @@
 				)
 			];
 		for (const [m, s] of min.entries()) {
+			out[m].dataset.raw = String(s);
 			out[m].textContent = vls[m] > 0 ? numberFormat.format(s) : '-';
 		}
 
@@ -715,6 +727,7 @@
 				)
 			];
 		for (const [m, s] of max.entries()) {
+			out[m].dataset.raw = vls[m];
 			out[m].textContent = vls[m] > 0 ? numberFormat.format(s) : '-';
 		}
 
@@ -756,10 +769,14 @@
 			}
 			col = document.createElement('TD');
 			col.classList.add('right');
+			col.dataset.raw = String(d.count);
 			col.textContent = numberFormat.format(d.count);
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('right');
+			col.dataset.raw = String(
+				Math.round((d.count / total) * 10000) / 100
+			);
 			col.textContent = numberFormatPercent.format(d.count / total);
 			row.appendChild(col);
 
@@ -768,7 +785,9 @@
 
 		updateTable(tbody, rows);
 
+		sumRow[sumRow.length - 2].dataset.raw = String(total);
 		sumRow[sumRow.length - 2].textContent = numberFormat.format(total);
+		sumRow[sumRow.length - 1].dataset.raw = '1';
 		sumRow[sumRow.length - 1].textContent = numberFormatPercent.format(1);
 
 		addExportButton(table);
@@ -906,7 +925,11 @@
 				Array.from(table.rows)
 					.map((row) =>
 						Array.from(row.cells)
-							.map((col) => col.innerText)
+							.map(
+								(col) =>
+									col.dataset.raw ??
+									`"${col.innerText.replaceAll('"', '""')}"`
+							)
 							.join(',')
 					)
 					.join('\r\n');

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -120,7 +120,7 @@
 			data.forEach((post) => {
 				const opt = document.createElement('option');
 				opt.value = post.url;
-				opt.innerText = post.title;
+				opt.textContent = post.title;
 				controls.postList.appendChild(opt);
 			})
 		);
@@ -486,7 +486,7 @@
 
 			labels.forEach((l) => {
 				const li = document.createElement('LI');
-				li.innerText = l;
+				li.textContent = l;
 				legend.appendChild(li);
 			});
 
@@ -553,7 +553,7 @@
 			const row = document.createElement('TR');
 			let col = document.createElement('TD');
 			col.classList.add('b');
-			col.innerText = numberFormat.format(r.count);
+			col.textContent = numberFormat.format(r.count);
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('t');
@@ -561,7 +561,7 @@
 			link.href = r.url;
 			link.target = '_blank';
 			link.rel = 'noopener noreferrer';
-			link.innerText = r.host || r.url;
+			link.textContent = r.host || r.url;
 			col.appendChild(link);
 			row.appendChild(col);
 			return row;
@@ -580,21 +580,21 @@
 		const rowToday = document.createElement('TR');
 		let col = document.createElement('TD');
 		col.classList.add('b');
-		col.innerText = numberFormat.format(data.today);
+		col.textContent = numberFormat.format(data.today);
 		rowToday.appendChild(col);
 		col = document.createElement('TD');
 		col.classList.add('t');
-		col.innerText = wp.i18n.__('today', 'statify');
+		col.textContent = wp.i18n.__('today', 'statify');
 		rowToday.appendChild(col);
 
 		const rowAll = document.createElement('TR');
 		col = document.createElement('TD');
 		col.classList.add('b');
-		col.innerText = numberFormat.format(data.alltime);
+		col.textContent = numberFormat.format(data.alltime);
 		rowAll.appendChild(col);
 		col = document.createElement('TD');
 		col.classList.add('t');
-		col.innerText = wp.i18n.sprintf(
+		col.textContent = wp.i18n.sprintf(
 			/* translators: %s: Date. */
 			wp.i18n.__('since %s', 'statify'),
 			dateFormatYMD.format(new Date(data.since))
@@ -620,12 +620,12 @@
 			let col = document.createElement('TH');
 			let sum = 0;
 			col.scope = 'row';
-			col.innerText = year;
+			col.textContent = year;
 			row.appendChild(col);
 
 			for (let month = 1; month <= 12; month++) {
 				col = document.createElement('TD');
-				col.innerText =
+				col.textContent =
 					month in data.visits[year]
 						? numberFormat.format(data.visits[year][month])
 						: '-';
@@ -635,7 +635,7 @@
 
 			col = document.createElement('TD');
 			col.classList.add('statify-table-sum');
-			col.innerText = numberFormat.format(sum);
+			col.textContent = numberFormat.format(sum);
 			row.appendChild(col);
 
 			tbody.insertBefore(row, tbody.firstChild);
@@ -667,7 +667,7 @@
 			++vls[m];
 			min[m] = Math.min(min[m], count);
 			max[m] = Math.max(max[m], count);
-			out[d.getDate() - 1][m].innerText = numberFormat.format(count);
+			out[d.getDate() - 1][m].textContent = numberFormat.format(count);
 		}
 
 		out =
@@ -684,11 +684,13 @@
 			];
 		for (const [m, s] of sum.entries()) {
 			if (vls[m] > 0) {
-				out[m].innerText = numberFormat.format(s);
-				avg[m].innerText = numberFormat.format(Math.round(s / vls[m]));
+				out[m].textContent = numberFormat.format(s);
+				avg[m].textContent = numberFormat.format(
+					Math.round(s / vls[m])
+				);
 			} else {
-				out[m].innerText = '-';
-				avg[m].innerText = '-';
+				out[m].textContent = '-';
+				avg[m].textContent = '-';
 			}
 		}
 
@@ -699,7 +701,7 @@
 				)
 			];
 		for (const [m, s] of min.entries()) {
-			out[m].innerText = vls[m] > 0 ? numberFormat.format(s) : '-';
+			out[m].textContent = vls[m] > 0 ? numberFormat.format(s) : '-';
 		}
 
 		out =
@@ -709,7 +711,7 @@
 				)
 			];
 		for (const [m, s] of max.entries()) {
-			out[m].innerText = vls[m] > 0 ? numberFormat.format(s) : '-';
+			out[m].textContent = vls[m] > 0 ? numberFormat.format(s) : '-';
 		}
 
 		for (const row of rows) {
@@ -737,24 +739,24 @@
 			let col = document.createElement('TD');
 			const link = document.createElement('A');
 			link.href = d.url;
-			link.innerText = d.title;
+			link.textContent = d.title;
 			col.append(link);
 			row.appendChild(col);
 			col = document.createElement('TD');
-			col.innerText = d.url;
+			col.textContent = d.url;
 			row.appendChild(col);
 			if (showType) {
 				col = document.createElement('TD');
-				col.innerText = d.typeName;
+				col.textContent = d.typeName;
 				row.appendChild(col);
 			}
 			col = document.createElement('TD');
 			col.classList.add('right');
-			col.innerText = numberFormat.format(d.count);
+			col.textContent = numberFormat.format(d.count);
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('right');
-			col.innerText = numberFormatPercent.format(d.count / total);
+			col.textContent = numberFormatPercent.format(d.count / total);
 			row.appendChild(col);
 
 			return row;
@@ -762,8 +764,8 @@
 
 		updateTable(tbody, rows);
 
-		sumRow[sumRow.length - 2].innerText = numberFormat.format(total);
-		sumRow[sumRow.length - 1].innerText = numberFormatPercent.format(1);
+		sumRow[sumRow.length - 2].textContent = numberFormat.format(total);
+		sumRow[sumRow.length - 1].textContent = numberFormatPercent.format(1);
 
 		addExportButton(table);
 	}
@@ -785,24 +787,24 @@
 			let col = document.createElement('TD');
 			const link = document.createElement('A');
 			link.href = d.url;
-			link.innerText = d.host;
+			link.textContent = d.host;
 			col.append(link);
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('right');
-			col.innerText = numberFormat.format(d.count);
+			col.textContent = numberFormat.format(d.count);
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('right');
-			col.innerText = numberFormatPercent.format(d.count / total);
+			col.textContent = numberFormatPercent.format(d.count / total);
 			row.appendChild(col);
 			return row;
 		});
 
 		updateTable(tbody, rows);
 
-		sumRow[sumRow.length - 2].innerText = numberFormat.format(total);
-		sumRow[sumRow.length - 1].innerText = numberFormatPercent.format(1);
+		sumRow[sumRow.length - 2].textContent = numberFormat.format(total);
+		sumRow[sumRow.length - 1].textContent = numberFormatPercent.format(1);
 
 		addExportButton(table);
 	}
@@ -893,7 +895,7 @@
 			'.csv';
 
 		// Generate CSV on demand.
-		exportBtn.innerText = wp.i18n.__('Export (CSV)', 'statify');
+		exportBtn.textContent = wp.i18n.__('Export (CSV)', 'statify');
 		exportBtn.addEventListener('click', () => {
 			exportBtn.href =
 				'data:text/csv;charset=utf-8,' +
@@ -1018,7 +1020,7 @@
 	 */
 	function msg(element, text) {
 		const p = document.createElement('p');
-		p.innerText = text;
+		p.textContent = text;
 		element.innerHTML = '';
 		element.appendChild(p);
 	}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -180,7 +180,7 @@
 	}
 
 	/**
-	 * Load monthly statistics.
+	 * Load daily statistics.
 	 *
 	 * @param {number} year Year to load data for.
 	 *
@@ -335,7 +335,7 @@
 	 */
 	function renderYearly(root, data) {
 		const labels = Object.keys(data.visits);
-		const values = Object.values(data.visits).flatMap((y) =>
+		const values = Object.values(data.visits).map((y) =>
 			Object.values(y).reduce((a, b) => a + b, 0)
 		);
 


### PR DESCRIPTION
* use `map()` instead of `flatMap()` in `renderYearly()`
* perfer `textContent` over `innerText` to reduce rendering overhead
* guard URLs from API response before rendering link elements (prevent injections)
* use raw numbers in CSV export and quote strings to prevent corruption