### PR TITLE
Fix sprintf placeholder typo in referrers date range heading

### DIFF
--- a/views/view-referrers.php
+++ b/views/view-referrers.php
@@ -34,7 +34,7 @@ $selected_post_title = Statify_Evaluation::post_title( $selected_post );
 if ( ! empty( $date_start ) && ! empty( $date_end ) && $date_start !== $date_end ) {
 	$section_title = sprintf(
 		/* translators: 1: start date, 2: end date, 3: post title or "all posts" */
-		__( 'Referrers from other websites from %1$s to %3$s for %3$s', 'statify' ),
+		__( 'Referrers from other websites from %1$s to %2$s for %3$s', 'statify' ),
 		Statify::parse_date( $date_start ),
 		Statify::parse_date( $date_end ),
 		$selected_post_title


### PR DESCRIPTION
Hey folks,

Spotted a small typo in the referrers heading string. When a date range is set, the format string uses %3$s twice — once in the "to" position and again for the post title — so the end date is silently dropped and the post title appears in both spots. The translator comment right above it correctly documents the intent (1: start date, 2: end date, 3: post title), so this is just a copy-paste slip in the string itself. One character fix.

(full disclosure, I used AI help with the testing and tweaks - Christopher)