### PR TITLE
fix off-by-one error in date formatting (#328)

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -312,7 +312,7 @@
 			} else {
 				labels = labels.flatMap((y) =>
 					Object.keys(data.visits[y]).map((m) =>
-						dateFormatYM.format(new Date(y, m))
+						dateFormatYM.format(new Date(y, m - 1))
 					)
 				);
 			}


### PR DESCRIPTION
API months are 1-based while Date objects expect 0-based values.
Fix the offset while generating year/month labels for extended overview charts.

Resolves #328

Fixes: a966ca6125821dd9216dbfcf318520889c9e9973