### PR TITLE
allow relative URLs to be linked in dashboard widget

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -557,7 +557,7 @@
 			row.appendChild(col);
 			col = document.createElement('TD');
 			col.classList.add('t');
-			if (/^https?:\/\//i.test(r.url)) {
+			if (/^((https?:)?\/)?\//i.test(r.url)) {
 				const link = document.createElement('A');
 				link.href = r.url;
 				link.target = '_blank';


### PR DESCRIPTION
Previously introduced filter to prevent injections only accepts absolute URLs starting with "http(s)://". Top-targets are served as relative links in API responses and no longer linked.

Extend the filter to allow protocol-relative and relative URLs.

Fixes: 929a25934998c40843c1211532512f0e76f87c85