### PR TITLE
remove "amp/" suffix from target URLs (#183)

### DIFF
--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -153,7 +153,7 @@ class Statify_Frontend extends Statify {
 			),
 			'extraUrlParams' => array(
 				'referrer' => '${documentReferrer}',
-				'target'   => '${canonicalPath}amp/',
+				'target'   => '${canonicalPath}',
 			),
 			'triggers'       => array(
 				'trackPageview' => array(


### PR DESCRIPTION
We used to add "amp/" to the target URL for AMP tracking. As pointed out years ago this not "correct" and should rather be a "?amp" parameter.

As the target refers to a specific page and the requested content should be the same whether called via desktop, mobile or AMP there's not really a point in marking AMP calls explicitly. We should drop the special treatment for this case.

Remove the suffix completely and keep the AMP hooks if a site still uses them.

----

resolves #183 
supersedes #195 