### PR TITLE
make widget title translatable

### DIFF
--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -40,7 +40,7 @@ class Statify_Dashboard extends Statify {
 		// Add dashboard widget.
 		wp_add_dashboard_widget(
 			'statify_dashboard',
-			'Statify',
+			__( 'Statify', 'statify' ),
 			array( __CLASS__, 'print_frontview' ),
 			array( __CLASS__, 'print_backview' )
 		);


### PR DESCRIPTION
Side quest of https://github.com/pluginkollektiv/statify/pull/334#discussion_r3408152480

We have `'Statify'` translatable in various places, but hard-coded in the dashboard widget title. Make it translatable, too.