### PR TITLE
simplify multisite iteration in (un)install routine

### DIFF
--- a/inc/class-statify-install.php
+++ b/inc/class-statify-install.php
@@ -29,14 +29,11 @@ class Statify_Install {
 	public static function init( bool $network_wide = false ): void {
 
 		if ( $network_wide && is_multisite() ) {
-			$sites = get_sites();
+			$sites = get_sites( array( 'fields' => 'ids' ) );
 
 			// Create tables for each site in a network.
 			foreach ( $sites as $site ) {
-				// Convert object to array.
-				$site = (array) $site;
-
-				switch_to_blog( $site['blog_id'] );
+				switch_to_blog( $site );
 				self::apply();
 			}
 
@@ -55,7 +52,7 @@ class Statify_Install {
 	 */
 	public static function init_site( WP_Site $new_site ): void {
 
-		switch_to_blog( $new_site->site_id );
+		switch_to_blog( (int) $new_site->site_id );
 
 		self::apply();
 

--- a/inc/class-statify-uninstall.php
+++ b/inc/class-statify-uninstall.php
@@ -27,13 +27,10 @@ class Statify_Uninstall {
 	public static function init(): void {
 		if ( is_multisite() ) {
 			$old   = get_current_blog_id();
-			$sites = get_sites();
+			$sites = get_sites( array( 'fields' => 'ids' ) );
 
 			foreach ( $sites as $site ) {
-				// Convert object to array.
-				$site = (array) $site;
-
-				switch_to_blog( $site['blog_id'] );
+				switch_to_blog( $site );
 				self::apply();
 			}
 
@@ -52,7 +49,7 @@ class Statify_Uninstall {
 	 */
 	public static function init_site( WP_Site $old_site ): void {
 
-		switch_to_blog( $old_site->site_id );
+		switch_to_blog( (int) $old_site->site_id );
 
 		self::apply();
 


### PR DESCRIPTION
We do not require the full site object, so let's just fetch IDs and omit legacy array conversion.