### PR TITLE
add some missing type hints and simple array types

### DIFF
--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -125,6 +125,8 @@ class Statify_Api extends Statify {
 	 *
 	 * @param WP_Error|null|true $errors WP_Error if authentication error, null if authentication
 	 *                                   method wasn't used, true if authentication succeeded.
+	 *
+	 * @return WP_Error|null|true True if our REST route was called, pass-through argument otherwise.
 	 */
 	public static function check_authentication( $errors ) {
 		$route = untrailingslashit( $GLOBALS['wp']->query_vars['rest_route'] );
@@ -336,7 +338,7 @@ class Statify_Api extends Statify {
 				Statify_Evaluation::get_post_urls()
 			);
 
-			self::update_cache( 'post_urls', 0, $posts );
+			self::update_cache( 'post_urls', '0', $posts );
 		}
 
 		return new WP_REST_Response( $posts );

--- a/inc/class-statify-backend.php
+++ b/inc/class-statify-backend.php
@@ -24,10 +24,10 @@ class Statify_Backend {
 	 * @since    0.1.0
 	 * @version  1.4.0
 	 *
-	 * @param   array  $input Registered links.
-	 * @param   string $file  Current plugin file.
+	 * @param string[] $input Registered links.
+	 * @param string   $file  Current plugin file.
 	 *
-	 * @return  array           Merged links
+	 * @return string[] Merged links
 	 */
 	public static function add_meta_link( array $input, string $file ): array {
 
@@ -51,9 +51,9 @@ class Statify_Backend {
 	 * @since   0.1.0
 	 * @version 1.4.0
 	 *
-	 * @param   array $input Registered links.
+	 * @param string[] $input Registered links.
 	 *
-	 * @return  array           Merged links
+	 * @return string[] Merged links
 	 */
 	public static function add_action_link( array $input ): array {
 

--- a/inc/class-statify-frontend.php
+++ b/inc/class-statify-frontend.php
@@ -51,9 +51,9 @@ class Statify_Frontend extends Statify {
 	 * @since    1.1.0
 	 * @version  1.3.1
 	 *
-	 * @param   array $vars Input with existing variables.
+	 * @param string[] $vars Input with existing variables.
 	 *
-	 * @return  array  $vars  Output with plugin variables
+	 * @return string[] Output with plugin variables
 	 */
 	public static function query_vars( array $vars ): array {
 		$vars[] = 'statify_referrer';

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -187,7 +187,7 @@ class Statify_Settings {
 	private static function show_snippet_option( int $value, string $label ): void {
 		?>
 			<label>
-				<input name="statify[snippet]" type="radio" value="<?php echo esc_html( $value ); ?>" <?php checked( Statify::$options['snippet'], $value ); ?>>
+				<input name="statify[snippet]" type="radio" value="<?php echo esc_html( (string) $value ); ?>" <?php checked( Statify::$options['snippet'], $value ); ?>>
 				<?php echo esc_html( $label ); ?>
 			</label>
 		<?php

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -445,9 +445,9 @@ class Statify {
 	}
 
 	/**
-	 * Get a array from the disallowed_keys option of 'Settings' - 'Discussion' - 'Disallowed Comment Keys'.
+	 * Get an array from the disallowed_keys option of 'Settings' - 'Discussion' - 'Disallowed Comment Keys'.
 	 *
-	 * @return array
+	 * @return string[]
 	 *
 	 * @since 1.7.3 Renamed to "get_disallowed_keys" to match WP 5.5. wording.
 	 * @since 2.0.0 Migration from Statify_Frontend to Statify class.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,12 @@
 parameters:
-  level: 3
+  level: 5
   paths:
     - inc/
     - views/
     - statify.php
   ignoreErrors:
     - '/^Constant STATIFY_BASE not found\.$/'
+    - message: '/^Parameter \#1 \$text of function esc_(attr|html) expects string, int.* given\.$/'
+      path: views/view-dashboard.php
+  # Some WP built-ins contain pluggable behavior that might not be perfectly type-safe.
+  treatPhpDocTypesAsCertain: false

--- a/statify.php
+++ b/statify.php
@@ -64,7 +64,7 @@ spl_autoload_register( 'statify_autoload' );
  *
  * @param string $class Name of an class-file name, without file extension.
  */
-function statify_autoload( $class ) {
+function statify_autoload( string $class ): void {
 
 	$plugin_classes = array(
 		'Statify',

--- a/statify.php
+++ b/statify.php
@@ -18,43 +18,17 @@
 /* Quit */
 defined( 'ABSPATH' ) || exit;
 
-
 /*  Constants */
 define( 'STATIFY_FILE', __FILE__ );
 define( 'STATIFY_DIR', __DIR__ );
 define( 'STATIFY_BASE', plugin_basename( __FILE__ ) );
 define( 'STATIFY_VERSION', '2.0.0' );
 
-
 /* Hooks */
-add_action(
-	'plugins_loaded',
-	array(
-		'Statify',
-		'init',
-	)
-);
-register_activation_hook(
-	STATIFY_FILE,
-	array(
-		'Statify_Install',
-		'init',
-	)
-);
-register_deactivation_hook(
-	STATIFY_FILE,
-	array(
-		'Statify_Deactivate',
-		'init',
-	)
-);
-register_uninstall_hook(
-	STATIFY_FILE,
-	array(
-		'Statify_Uninstall',
-		'init',
-	)
-);
+add_action( 'plugins_loaded', array( 'Statify', 'init' ) );
+register_activation_hook( STATIFY_FILE, array( 'Statify_Install', 'init' ) );
+register_deactivation_hook( STATIFY_FILE, array( 'Statify_Deactivate', 'init' ) );
+register_uninstall_hook( STATIFY_FILE, array( 'Statify_Uninstall', 'init' ) );
 
 /* Autoload */
 spl_autoload_register( 'statify_autoload' );


### PR DESCRIPTION
Use e.g. `string[]` instead of `array` where the type is known. This allows raising PHPStan level to 5 if we ignore strict string/int types for `esc_html()` calls.