### PR TITLE
code clean-up, alignments and PHPCS rules update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "slowprog/composer-copy-file": "^0.3",
     "squizlabs/php_codesniffer": "^3.13",
     "szepeviktor/phpstan-wordpress": "^v2.0",
-    "wp-coding-standards/wpcs": "^3.3",
+    "wp-coding-standards/wpcs": "^3.4",
     "yoast/phpunit-polyfills": "^1.1"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "214c2ff51374886a992e0cde0a5aa8c5",
+    "content-hash": "4c9ce40ae36504cc428df729fc52d98e",
     "packages": [
         {
             "name": "jaybizzle/crawler-detect",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JayBizzle/Crawler-Detect.git",
-                "reference": "20d7bd4a6ee68444693fe75bc5c6f12f65ad512d"
+                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/20d7bd4a6ee68444693fe75bc5c6f12f65ad512d",
-                "reference": "20d7bd4a6ee68444693fe75bc5c6f12f65ad512d",
+                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/770e00e5bcd35054871a6f790f380123cc3b8b0c",
+                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c",
                 "shasum": ""
             },
             "require": {
@@ -54,9 +54,9 @@
             ],
             "support": {
                 "issues": "https://github.com/JayBizzle/Crawler-Detect/issues",
-                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.4.0"
+                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.4.1"
             },
-            "time": "2026-06-11T18:29:41+00:00"
+            "time": "2026-07-10T14:15:38+00:00"
         }
     ],
     "packages-dev": [
@@ -411,20 +411,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -463,9 +462,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1452,25 +1451,25 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.34",
+            "version": "9.6.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -1535,31 +1534,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:45:00+00:00"
+            "time": "2026-07-06T14:48:07+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2818,16 +2801,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
                 "shasum": ""
             },
             "require": {
@@ -2837,8 +2820,8 @@
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
                 "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsutils": "^1.2.2",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -2880,7 +2863,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-16T13:05:29+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -2948,12 +2931,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.4|^8"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -22,14 +22,14 @@ class Statify_Api extends Statify {
 	 *
 	 * @var    string
 	 */
-	const REST_NAMESPACE = 'statify/v1';
-	const REST_ROUTE_TRACK = 'track';
-	const REST_ROUTE_STATS = 'stats';
-	const REST_ROUTE_RESET = 'reset';
-	const REST_ROUTE_STATS_EXTENDED = 'stats/extended';
-	const REST_ROUTE_STATS_POSTS = 'stats/posts';
+	const REST_NAMESPACE             = 'statify/v1';
+	const REST_ROUTE_TRACK           = 'track';
+	const REST_ROUTE_STATS           = 'stats';
+	const REST_ROUTE_RESET           = 'reset';
+	const REST_ROUTE_STATS_EXTENDED  = 'stats/extended';
+	const REST_ROUTE_STATS_POSTS     = 'stats/posts';
 	const REST_ROUTE_STATS_REFERRERS = 'stats/referrers';
-	const REST_ROUTE_POSTS = 'posts';
+	const REST_ROUTE_POSTS           = 'posts';
 
 	/**
 	 * Initialize REST API routes.
@@ -252,7 +252,7 @@ class Statify_Api extends Statify {
 	public static function get_extended( WP_REST_Request $request ): WP_REST_Response {
 		// Verify scope.
 		$scope = $request->get_param( 'scope' );
-		if ( ! in_array( $scope, array( 'year', 'month', 'day' ) ) ) {
+		if ( ! in_array( $scope, array( 'year', 'month', 'day' ), true ) ) {
 			return new WP_REST_Response(
 				array( 'error' => 'invalid scope (allowed: year, month, day)' ),
 				400
@@ -436,12 +436,12 @@ class Statify_Api extends Statify {
 	 */
 	public static function get_stats_referrers( WP_REST_Request $request ): WP_REST_Response {
 		// Single post requested?
-		$post  = $request->get_param( 'post' );
+		$post = $request->get_param( 'post' );
 
 		// Date filter.
 		$start = self::get_date( $request, 'start' );
 		$end   = self::get_date( $request, 'end' );
-		$data = false;
+		$data  = false;
 		if ( empty( $post ) && empty( $start ) && empty( $end ) ) {
 			// Retrieve data from cache.
 			$data = self::from_cache( 'referrers' );

--- a/inc/class-statify-backend.php
+++ b/inc/class-statify-backend.php
@@ -69,9 +69,11 @@ class Statify_Backend {
 				sprintf(
 					/* @lang  Disable language injection for Url query argument. */
 					'<a href="%s">%s</a>',
-					add_query_arg(
-						array( 'page' => 'statify-settings' ),
-						admin_url( '/options-general.php' )
+					esc_url(
+						add_query_arg(
+							array( 'page' => 'statify-settings' ),
+							admin_url( '/options-general.php' )
+						)
 					),
 					esc_html__( 'Settings', 'statify' )
 				),

--- a/inc/class-statify-dashboard.php
+++ b/inc/class-statify-dashboard.php
@@ -202,7 +202,7 @@ class Statify_Dashboard extends Statify {
 		$current_date = current_time( 'Y-m-d' );
 
 		$data = array(
-			'visits'   => self::fill_gaps(
+			'visits' => self::fill_gaps(
 				$wpdb->get_results(
 					$wpdb->prepare(
 						"SELECT `created` as `date`, COUNT(*) as `count` FROM `$wpdb->statify` WHERE `created` BETWEEN CURDATE() - INTERVAL %d DAY AND CURDATE() GROUP BY `created` ORDER BY `created` ASC",
@@ -223,6 +223,7 @@ class Statify_Dashboard extends Statify {
 				),
 				ARRAY_A
 			);
+
 			$data['referrer'] = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT COUNT(`referrer`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created = %s GROUP BY `host` ORDER BY `count` DESC, `url` ASC LIMIT %d",
@@ -241,6 +242,7 @@ class Statify_Dashboard extends Statify {
 				),
 				ARRAY_A
 			);
+
 			$data['referrer'] = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT COUNT(`referrer`) as `count`, `referrer` as `url`, SUBSTRING_INDEX(SUBSTRING_INDEX(TRIM(LEADING 'www.' FROM(TRIM(LEADING 'https://' FROM TRIM(LEADING 'http://' FROM TRIM(`referrer`))))), '/', 1), ':', 1) as `host` FROM `$wpdb->statify` WHERE `referrer` != '' AND created > DATE_SUB(%s, INTERVAL %d DAY) GROUP BY `host` ORDER BY `count` DESC, `url` ASC LIMIT %d",
@@ -293,7 +295,7 @@ class Statify_Dashboard extends Statify {
 	 * @return array Array with filled gaps.
 	 */
 	private static function fill_gaps( array $data, int $days ): array {
-		if ( empty( $data ) || count( $data ) == $days ) {
+		if ( empty( $data ) || count( $data ) === $days ) {
 			return $data;
 		}
 

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -69,6 +69,7 @@ class Statify_Evaluation extends Statify {
 			'content'   => __( 'Content', 'statify' ),
 			'referrers' => __( 'Referrers', 'statify' ),
 		);
+		// phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found
 		?>
 		<nav class="statify-page-nav nav-tab-wrapper wp-clearfix" aria-label="<?php esc_attr_e( 'Statify evaluation', 'statify' ); ?>">
 			<?php foreach ( $pages as $view => $label ) : ?>
@@ -79,6 +80,7 @@ class Statify_Evaluation extends Statify {
 			<?php endforeach; ?>
 		</nav>
 		<?php
+		// phpcs:enable Universal.WhiteSpace.PrecisionAlignment.Found
 	}
 
 	/**
@@ -113,12 +115,14 @@ class Statify_Evaluation extends Statify {
 	 */
 	public static function show_dashboard(): void {
 		$view = 'dashboard';
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['view'] ) ) {
 			$view = sanitize_key( wp_unslash( $_GET['view'] ) );
 			if ( ! in_array( $view, array( 'dashboard', 'content', 'referrers' ), true ) ) {
 				$view = 'dashboard';
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		self::show_view( $view );
 	}
 
@@ -150,6 +154,7 @@ class Statify_Evaluation extends Statify {
 			' ORDER BY `year` DESC',
 			ARRAY_A
 		);
+
 		$years = array();
 		foreach ( $results as $result ) {
 			$years[] = (int) $result['year'];
@@ -439,7 +444,7 @@ class Statify_Evaluation extends Statify {
 	 */
 	public static function get_post_types(): array {
 		$types_args = array(
-			'public' => true,
+			'public'   => true,
 			'_builtin' => false,
 		);
 

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -272,7 +272,7 @@ class Statify_Settings {
 
 			foreach ( $all_roles as $role => $role_object ) {
 				$capabilities = $role_object['capabilities'];
-				if ( in_array( 'edit_dashboard', array_keys( $capabilities ) ) ) {
+				if ( in_array( 'edit_dashboard', array_keys( $capabilities ), true ) ) {
 					$saved_roles[] = $role;
 				}
 			}
@@ -303,7 +303,7 @@ class Statify_Settings {
 				esc_html( $input_id ),
 				esc_html( $role ),
 				esc_html( $name ),
-				checked( in_array( $role, $saved_roles ), true, false )
+				checked( in_array( $role, $saved_roles, true ), true, false )
 			);
 			echo esc_html( $role_object['name'] );
 			?>
@@ -463,6 +463,7 @@ class Statify_Settings {
 		// Sanitize user roles (preserve NULL, if unset).
 		if ( isset( $options['show_widget_roles'] ) ) {
 			$available_roles = apply_filters( 'statify__available_roles', wp_roles()->roles );
+
 			$res['show_widget_roles'] = array();
 			foreach ( $options['show_widget_roles'] as $saved_role ) {
 				if ( in_array( $saved_role, array_keys( $available_roles ), true ) ) {

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -17,12 +17,12 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.1.0
  */
 class Statify {
-	const TRACKING_METHOD_DEFAULT = 0;
-	const TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK = 1;
+	const TRACKING_METHOD_DEFAULT                        = 0;
+	const TRACKING_METHOD_JAVASCRIPT_WITH_NONCE_CHECK    = 1;
 	const TRACKING_METHOD_JAVASCRIPT_WITHOUT_NONCE_CHECK = 2;
 
-	const SKIP_USERS_NONE = 0;
-	const SKIP_USERS_ALL = 1;
+	const SKIP_USERS_NONE  = 0;
+	const SKIP_USERS_ALL   = 1;
 	const SKIP_USERS_ADMIN = 2;
 
 	/**
@@ -221,12 +221,12 @@ class Statify {
 	public static function user_can_see_stats(): bool {
 		if ( isset( self::$options['show_widget_roles'] ) ) {
 			$statify_roles = self::$options['show_widget_roles'];
-			$current_user = wp_get_current_user();
-			$user_roles = $current_user->roles;
+			$current_user  = wp_get_current_user();
+			$user_roles    = $current_user->roles;
 
 			// Filter user_can_see_stats.
 			$allowed_roles = array_intersect( $statify_roles, $user_roles );
-			$can_see = ! empty( $allowed_roles );
+			$can_see       = ! empty( $allowed_roles );
 		} else {
 			// Backwards compatibility for older statify versions without this option.
 			$can_see = current_user_can( 'edit_dashboard' );
@@ -316,7 +316,7 @@ class Statify {
 	 */
 	protected static function get_version(): string {
 		if ( ! isset( self::$plugin_version ) ) {
-			$meta = get_plugin_data( STATIFY_FILE );
+			$meta                 = get_plugin_data( STATIFY_FILE );
 			self::$plugin_version = $meta['Version'];
 		}
 
@@ -428,7 +428,7 @@ class Statify {
 			$referrer = $referrer['host'];
 		}
 
-		// Return false if there still is no referrer to checj.
+		// Return false if there still is no referrer to check.
 		if ( ! is_string( $referrer ) ) {
 			return false;
 		}
@@ -468,18 +468,17 @@ class Statify {
 	}
 
 	/**
-	 * Find the position of the first occurrence of a substring in a string about a array.
+	 * Check whether any of the given substrings occurs in a string.
 	 *
-	 * @param string  $haystack The string to search in.
-	 * @param array   $needle   The string to search for.
-	 * @param integer $offset   Search will start this number of characters counted from the beginning of the string.
+	 * @param string $haystack The string to search in.
+	 * @param array  $needle   The string to search for.
 	 *
 	 * @return boolean
 	 */
-	private static function strposa( string $haystack, array $needle, int $offset = 0 ): bool {
+	private static function strposa( string $haystack, array $needle ): bool {
 
 		foreach ( $needle as $query ) {
-			if ( strpos( $haystack, $query, $offset ) !== false ) {
+			if ( strpos( $haystack, $query ) !== false ) {
 				return true;
 			} // Stop on first true result.
 		}

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -460,8 +460,6 @@ class Statify {
 			$disallowed_keys = get_option( 'blacklist_keys' ); // phpcs:ignore WordPress.WP.DeprecatedParameterValues.Found
 		}
 
-		$disallowed_keys = trim( $disallowed_keys );
-
 		if ( empty( $disallowed_keys ) ) {
 			return array();
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,7 @@
 		 v flag: Print verbose output.
 		 n flag: Do not print warnings.
 	-->
-    <arg value="psvn"/>
+    <arg value="psv"/>
 
     <!-- use colors in output -->
     <arg name="colors"/>
@@ -22,14 +22,26 @@
     <!-- WordPress coding standards -->
     <config name="minimum_supported_wp_version" value="5.1" />
     <rule ref="WordPress">
-        <exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog" />
-        <exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />
-        <exclude name="WordPress.VIP.DirectDatabaseQuery.SchemaChange" />
-        <!-- Sanitization of $_SERVER causes problems with some PHP implementations -->
-        <exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized"/>
-        <!-- Precision alignment is used in HTML views -->
-        <exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+        <exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery" />
+        <exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching" />
+        <exclude name="WordPress.DB.DirectDatabaseQuery.SchemaChange" />
     </rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="statify"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="see_statify_evaluation"/>
+			</property>
+		</properties>
+	</rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
     <config name="testVersion" value="7.4-"/>

--- a/statify.php
+++ b/statify.php
@@ -36,9 +36,9 @@ spl_autoload_register( 'statify_autoload' );
 /**
  * Include classes via autoload.
  *
- * @param string $class Name of an class-file name, without file extension.
+ * @param string $class_name Name of an class-file name, without file extension.
  */
-function statify_autoload( string $class ): void {
+function statify_autoload( string $class_name ): void {
 
 	$plugin_classes = array(
 		'Statify',
@@ -55,17 +55,17 @@ function statify_autoload( string $class ): void {
 		'Statify_Cron',
 	);
 
-	if ( in_array( $class, $plugin_classes, true ) ) {
+	if ( in_array( $class_name, $plugin_classes, true ) ) {
 		require_once sprintf(
 			'%s/inc/class-%s.php',
 			STATIFY_DIR,
-			strtolower( str_replace( '_', '-', $class ) )
+			strtolower( str_replace( '_', '-', $class_name ) )
 		);
-	} elseif ( 0 === strncmp( $class, 'Jaybizzle\\CrawlerDetect\\', 24 ) && ! class_exists( $class, false ) ) {
+	} elseif ( 0 === strncmp( $class_name, 'Jaybizzle\\CrawlerDetect\\', 24 ) && ! class_exists( $class_name, false ) ) {
 		require_once sprintf(
 			'%s/lib/%s.php',
 			STATIFY_DIR,
-			str_replace( '\\', DIRECTORY_SEPARATOR, $class )
+			str_replace( '\\', DIRECTORY_SEPARATOR, $class_name )
 		);
 	}
 }

--- a/views/view-content.php
+++ b/views/view-content.php
@@ -9,6 +9,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- we use $_GET parameters in various places
+
 $post_types = Statify_Evaluation::get_post_types();
 if ( isset( $_GET['type'] ) && in_array( wp_unslash( $_GET['type'] ), $post_types, true ) ) {
 	$selected_type = sanitize_text_field( wp_unslash( $_GET['type'] ) );

--- a/views/view-dashboard.php
+++ b/views/view-dashboard.php
@@ -9,6 +9,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- we use $_GET parameters in various places
+
 if ( isset( $_GET['year'] ) ) {
 	$selected_year = intval( $_GET['year'] );
 } else {

--- a/views/view-referrers.php
+++ b/views/view-referrers.php
@@ -9,6 +9,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- we use $_GET parameters in various places
+
 if ( isset( $_GET['range'] ) ) {
 	$date_range = sanitize_text_field( wp_unslash( $_GET['range'] ) );
 } else {

--- a/views/widget-back.php
+++ b/views/widget-back.php
@@ -8,7 +8,10 @@
  */
 
 // Exit if accessed directly.
-defined( 'ABSPATH' ) || exit; ?>
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found
+?>
 
 <?php if ( current_user_can( 'manage_options' ) ) : ?>
 <p class="meta-links settings-link">


### PR DESCRIPTION
* remove redundant `trim()` cann in `get_disallowed_keys()`
* remove unused offset parameter of `strposa()` helper function
* escape URL in action links
* adjust alignments of equals signs and arrows
* use strict type comparison for `in_array()`
* rename parameter `$class` to `$class_name` in autoloader function
* update PHPCS ruleset and move narrow down excluded rules