### PR TITLE
fix: scroll to latest point in dashboard chart (#348)

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,6 +1,9 @@
 /* @group Front page */
 
 .statify-chart {
+	direction: ltr;
+	display: flex;
+	flex-direction: row-reverse;
 	color: #a7aaad;
 	flex: 0 0 100%;
 	height: 140px;
@@ -11,16 +14,12 @@
 }
 
 .statify-chart * {
-	direction: ltr;
-}
-
-body.rtl .statify-chart * {
-	direction: rtl;
+	flex-shrink: 0;
 }
 
 .statify-chart .spinner {
 	float: none;
-	margin: 1em;
+	margin: auto;
 }
 
 .statify-chart .ct-line {
@@ -207,6 +206,19 @@ body.rtl .statify-chart * {
 .statify-subnav li:not(:last-child)::after {
 	content: "|";
 	margin: 0 0.2em;
+}
+
+body.rtl .statify-chart {
+	transform: scaleX(-1);
+}
+
+body.rtl .statify-chart .ct-label {
+	transform: scaleX(-1);
+	transform-origin: center;
+}
+
+body.rtl .statify-chart * {
+	direction: rtl;
 }
 
 /* @end group */


### PR DESCRIPTION
We used some RTL/LTR tricks to make the dashboard widget scroll to the rightmost entry. This was removed during some refactoring of the widget code. Re-introduce this UI feature using flexbox row-reverse.

<img width="536" height="280" alt="screenshot_2026-07-31_17-49-13" src="https://github.com/user-attachments/assets/453fc267-1c3a-4227-8126-447a155133d2" />


Also use a double-flip trick to make the chart scroll to the left on RTL layouts.

<img width="536" height="280" alt="screenshot_2026-07-31_17-57-39" src="https://github.com/user-attachments/assets/b380ba11-7716-4fc9-a2dc-737ea20514a1" />

----

resolves #348