### PR TITLE
fix: add missing translations indicator for dashboard JS 

### DIFF
--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -273,6 +273,7 @@ class Statify {
 				'sitename' => sanitize_key( get_bloginfo( 'name' ) ),
 			)
 		);
+		wp_set_script_translations( 'statify_chart_js', 'statify' );
 	}
 
 	/**


### PR DESCRIPTION
Frontend texts properly run through `wp.i18n`, but a backend call to `wp_set_script_translations()`[^1] was missing, so the translations never actually got loaded and JS-generated output contains defaults.

Originally reported in the forums: https://wordpress.org/support/topic/the-language-issue-in-the-statify-dashboard-widget/

[^1]: https://developer.wordpress.org/reference/functions/wp_set_script_translations/