### PR TITLE
fix(363): ClassicPress wp.apiFetch polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.3
+
+### Fixes
+
+* Dashboard widgets and the settings reset option work again on ClassicPress (#363)
+
+
 ## 2.0.2
 
 ### Fixes

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -83,6 +83,7 @@ class Statify {
 			add_action( 'wp_initialize_site', array( 'Statify_Install', 'init_site' ) );
 			add_action( 'wp_uninitialize_site', array( 'Statify_Uninstall', 'init_site' ) );
 			add_action( 'wp_dashboard_setup', array( 'Statify_Dashboard', 'init' ) );
+			add_action( 'admin_enqueue_scripts', array( 'Statify', 'maybe_init_api_fetch_polyfill' ), 0 );
 			add_filter( 'plugin_row_meta', array( 'Statify_Backend', 'add_meta_link' ), 10, 2 );
 			add_filter( 'plugin_action_links_' . STATIFY_BASE, array( 'Statify_Backend', 'add_action_link' ) );
 			add_action( 'admin_init', array( 'Statify_Settings', 'register_settings' ) );
@@ -275,6 +276,45 @@ class Statify {
 			)
 		);
 		wp_set_script_translations( 'statify_chart_js', 'statify' );
+	}
+
+	/**
+	 * Replace the wp-api-fetch handle with a small plugin polyfill on ClassicPress.
+	 *
+	 * ClassicPress does not ship a working wp.apiFetch, so the dashboard widget and
+	 * the settings reset option fail. Registering the polyfill under the same handle
+	 * keeps every existing script dependency resolving without any further changes.
+	 *
+	 * @return void
+	 *
+	 * @since 2.0.3
+	 */
+	public static function maybe_init_api_fetch_polyfill(): void {
+		// Only ClassicPress needs the polyfill; WordPress uses the core script.
+		if ( ! function_exists( 'classicpress_version' ) ) {
+			return;
+		}
+
+		// Replace the broken core handle with the plugin polyfill.
+		wp_dequeue_script( 'wp-api-fetch' );
+		wp_deregister_script( 'wp-api-fetch' );
+
+		wp_register_script(
+			'wp-api-fetch',
+			plugins_url( 'js/api-fetch-polyfill.min.js', STATIFY_FILE ),
+			array(),
+			self::get_version(),
+			false // Load in head so it runs before the scripts that depend on it.
+		);
+		wp_localize_script(
+			'wp-api-fetch',
+			'statifyApiFetchConfig',
+			array(
+				'url'   => esc_url_raw( rest_url() ),
+				'nonce' => (string) wp_create_nonce( 'wp_rest' ),
+			)
+		);
+		wp_enqueue_script( 'wp-api-fetch' );
 	}
 
 	/**

--- a/js/api-fetch-polyfill.js
+++ b/js/api-fetch-polyfill.js
@@ -1,0 +1,200 @@
+(function (root) {
+	'use strict';
+
+	// ClassicPress does not ship a working wp.apiFetch. This tiny, original
+	// subset covers the surface Statify uses (path/method/headers/JSON) plus
+	// the middleware helpers some core inline scripts still call, so nothing
+	// throws. Regular WordPress keeps the core wp-api-fetch and never loads it.
+
+	// Read the localized config lazily so it is always the current value.
+	function getConfig() {
+		const cfg = root.statifyApiFetchConfig;
+		return cfg && typeof cfg === 'object' ? cfg : {};
+	}
+
+	// Build the request URL from the localized REST root and a relative path.
+	function buildUrl(options) {
+		if (options.url) {
+			return options.url;
+		}
+
+		const rootUrl = getConfig().url || '';
+		const base = rootUrl.endsWith('/') ? rootUrl : rootUrl + '/';
+		const path = String(options.path || '').replace(/^\/+/, '');
+		return base + path;
+	}
+
+	// A small middleware chain. Each middleware is called with (options, next).
+	// next() runs the next step; the last step performs the fetch.
+	const middlewares = [];
+	let fetchHandler = null;
+
+	function runMiddlewares(options) {
+		let index = 0;
+
+		function next() {
+			// Run the next registered middleware, or fall through to the handler.
+			const middleware = middlewares[index++];
+			if (typeof middleware === 'function') {
+				return middleware(options, next);
+			}
+
+			const transport = fetchHandler || defaultFetchHandler;
+			return transport(options);
+		}
+
+		return next();
+	}
+
+	function getHeaders(options, hasBody) {
+		const headers = {};
+
+		for (const name in options.headers) {
+			if (Object.prototype.hasOwnProperty.call(options.headers, name)) {
+				headers[name] = options.headers[name];
+			}
+		}
+
+		// The wp_rest nonce authorizes the request against the REST API. It is
+		// the default; a middleware may have set X-WP-Nonce already, in which
+		// case that value is kept.
+		if (!headers['X-WP-Nonce'] && getConfig().nonce) {
+			headers['X-WP-Nonce'] = getConfig().nonce;
+		}
+
+		if (hasBody) {
+			headers['Content-Type'] = 'application/json';
+		}
+
+		return headers;
+	}
+
+	function parseError(response, body) {
+		let code = 'statify_rest_error';
+		let message = String(response.status) + ' ' + response.statusText;
+		let data;
+
+		if (body && typeof body === 'object') {
+			if (body.code) {
+				code = body.code;
+			}
+			if (body.message) {
+				message = body.message;
+			}
+			if ('data' in body) {
+				data = body.data;
+			}
+		}
+
+		return { code, message, data };
+	}
+
+	function defaultFetchHandler(options) {
+		const method = (options.method || 'GET').toUpperCase();
+		const hasBody =
+			typeof options.data !== 'undefined' && options.data !== null;
+
+		const requestOptions = {
+			method,
+			headers: getHeaders(options, hasBody),
+			cache: 'no-store',
+		};
+
+		if (hasBody) {
+			requestOptions.body = JSON.stringify(options.data);
+		}
+
+		return fetch(buildUrl(options), requestOptions).then((response) => {
+			return response.text().then((text) => {
+				let parsed = null;
+				if (text) {
+					try {
+						parsed = JSON.parse(text);
+					} catch {
+						parsed = null;
+					}
+				}
+
+				if (!response.ok) {
+					throw parseError(response, parsed);
+				}
+
+				return parsed;
+			});
+		});
+	}
+
+	function apiFetch(options) {
+		return runMiddlewares(options || {});
+	}
+
+	// Middleware factories provided for compatibility with core inline scripts.
+	function createNonceMiddleware(nonce) {
+		return (options, next) => {
+			options = options || {};
+
+			if (nonce) {
+				if (
+					typeof options.headers !== 'object' ||
+					options.headers === null
+				) {
+					options.headers = {};
+				}
+				options.headers['X-WP-Nonce'] = nonce;
+			}
+
+			return next(options);
+		};
+	}
+
+	function createRootURLMiddleware(rootConfig) {
+		return (options, next) => {
+			options = options || {};
+
+			const rootUrl = rootConfig ? rootConfig.url : null;
+			if (rootUrl && !options.url && !options.path) {
+				options.url = rootUrl;
+			}
+
+			return next(options);
+		};
+	}
+
+	apiFetch.use = (middleware) => {
+		middlewares.push(middleware);
+	};
+	apiFetch.setFetchHandler = (handler) => {
+		fetchHandler = handler;
+	};
+	apiFetch.createNonceMiddleware = createNonceMiddleware;
+	apiFetch.createRootURLMiddleware = createRootURLMiddleware;
+
+	// Install onto wp, keeping any existing apiFetch that is already a function
+	// (e.g. a leftover ClassicPress object) but filling in the missing statics.
+	root.wp = root.wp || {};
+	const existingApiFetch = root.wp.apiFetch;
+
+	if (typeof existingApiFetch === 'function') {
+		if (typeof existingApiFetch.use !== 'function') {
+			existingApiFetch.use = apiFetch.use;
+		}
+		if (typeof existingApiFetch.setFetchHandler !== 'function') {
+			existingApiFetch.setFetchHandler = apiFetch.setFetchHandler;
+		}
+		if (typeof existingApiFetch.createNonceMiddleware !== 'function') {
+			existingApiFetch.createNonceMiddleware =
+				apiFetch.createNonceMiddleware;
+		}
+		if (typeof existingApiFetch.createRootURLMiddleware !== 'function') {
+			existingApiFetch.createRootURLMiddleware =
+				apiFetch.createRootURLMiddleware;
+		}
+	} else {
+		root.wp.apiFetch = apiFetch;
+	}
+
+	// Expose for Node tests; browsers use the wp.apiFetch install above.
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = root.wp.apiFetch;
+	}
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "copy-assets": "vendor-copy",
     "minify": "npm run minify:js && npm run minify:css",
     "minify:css": "esbuild css/dashboard.css css/settings.css --minify --outdir=css --outbase=. --entry-names=[name].min",
-    "minify:js": "esbuild js/dashboard.js js/settings.js js/snippet.js --minify --outdir=js --outbase=js --entry-names=[name].min",
+    "minify:js": "esbuild js/dashboard.js js/settings.js js/snippet.js js/api-fetch-polyfill.js --minify --outdir=js --outbase=js --entry-names=[name].min",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-css": "stylelint css/dashboard.css css/settings.css",
-    "lint-js": "eslint js/dashboard.js js/settings.js js/snippet.js",
+    "lint-js": "eslint js/dashboard.js js/settings.js js/snippet.js js/api-fetch-polyfill.js",
     "test": "nyc --reporter=text node --test tests/js/*.test.js"
   },
   "vendorCopy": [

--- a/tests/js/api-fetch-polyfill.test.js
+++ b/tests/js/api-fetch-polyfill.test.js
@@ -1,0 +1,192 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fakeXhr = require('nise').fakeXhr;
+
+// The polyfill installs into global.wp (its root in Node). require() runs the
+// module once; a fresh instance for each test is loaded in beforeEach after
+// clearing global.wp, so module-level state (middleware list, fetch handler)
+// never leaks between tests.
+let apiFetch;
+
+function jsonResponse(headers, body) {
+	return {
+		ok: headers.status >= 200 && headers.status < 300,
+		status: headers.status,
+		statusText: headers.statusText || '',
+		text: () => Promise.resolve(body),
+	};
+}
+
+describe('Statify API fetch polyfill', () => {
+	let xhrMock;
+	let requests = [];
+
+	beforeEach(() => {
+		global.statifyApiFetchConfig = {
+			url: 'https://wp.example.com/wp-json/',
+			nonce: '0123456789abcdef',
+		};
+
+		// Load a fresh module instance so middleware list and fetch handler
+		// (module-level state) start clean for this test.
+		apiFetch = require('../../js/api-fetch-polyfill');
+
+		xhrMock = fakeXhr.useFakeXMLHttpRequest();
+		requests = [];
+
+		// The polyfill uses fetch() API semantics; stub the global fetch to
+		// capture calls and return controlled responses.
+		global.fetch = (url, options) => {
+			const method = (options.method || 'GET').toUpperCase();
+			let body = null;
+			if (typeof options.body === 'string') {
+				try {
+					body = JSON.parse(options.body);
+				} catch {
+					body = options.body;
+				}
+			}
+			requests.push({ url, method, options, body });
+
+			if (url.includes('/error')) {
+				return Promise.resolve(
+					jsonResponse(
+						{ status: 403, statusText: 'Forbidden' },
+						JSON.stringify({
+							code: 'rest_forbidden',
+							message: 'Sorry.',
+							data: { status: 403 },
+						})
+					)
+				);
+			}
+
+			if (url.includes('/empty')) {
+				return Promise.resolve(
+					jsonResponse({ status: 200, statusText: 'OK' }, '')
+				);
+			}
+
+			return Promise.resolve(
+				jsonResponse(
+					{ status: 200, statusText: 'OK' },
+					JSON.stringify({ ok: true })
+				)
+			);
+		};
+	});
+
+	afterEach(() => {
+		xhrMock.restore();
+		delete global.fetch;
+		delete global.statifyApiFetchConfig;
+
+		// Remove the instance the module installed so the next require() (in
+		// beforeEach) starts a fresh one with empty module-level state.
+		if (global.wp) {
+			delete global.wp.apiFetch;
+		}
+		delete require.cache[require.resolve('../../js/api-fetch-polyfill')];
+	});
+
+	it('joins a relative path onto the localized REST root', async () => {
+		await apiFetch({ path: '/statify/v1/stats' });
+
+		assert.equal(requests.length, 1);
+		assert.equal(
+			requests[0].url,
+			'https://wp.example.com/wp-json/statify/v1/stats'
+		);
+	});
+
+	it('handles a path without a leading slash', async () => {
+		await apiFetch({ path: 'statify/v1/stats' });
+
+		assert.equal(
+			requests[0].url,
+			'https://wp.example.com/wp-json/statify/v1/stats'
+		);
+	});
+
+	it('supports an absolute url option', async () => {
+		await apiFetch({ url: 'https://other.example.com/custom' });
+
+		assert.equal(requests[0].url, 'https://other.example.com/custom');
+	});
+
+	it('sends POST with JSON body and content type', async () => {
+		await apiFetch({
+			path: '/statify/v1/reset',
+			method: 'POST',
+			data: { confirm: true },
+		});
+
+		assert.equal(requests.length, 1);
+		assert.equal(requests[0].method, 'POST');
+		assert.equal(
+			requests[0].options.headers['Content-Type'],
+			'application/json'
+		);
+		assert.deepEqual(requests[0].body, { confirm: true });
+	});
+
+	it('sends the wp_rest nonce on GET and POST', async () => {
+		await apiFetch({ path: '/statify/v1/stats' });
+		await apiFetch({ path: '/statify/v1/reset', method: 'POST' });
+
+		assert.equal(
+			requests[0].options.headers['X-WP-Nonce'],
+			'0123456789abcdef'
+		);
+		assert.equal(
+			requests[1].options.headers['X-WP-Nonce'],
+			'0123456789abcdef'
+		);
+	});
+
+	it('resolves parsed JSON on success', async () => {
+		const result = await apiFetch({ path: '/statify/v1/stats' });
+
+		assert.deepEqual(result, { ok: true });
+	});
+
+	it('resolves null on an empty response', async () => {
+		const result = await apiFetch({ path: '/statify/v1/empty' });
+
+		assert.equal(result, null);
+	});
+
+	it('rejects with the REST error shape on failure', async () => {
+		await assert.rejects(
+			apiFetch({ path: '/statify/v1/error' }),
+			(error) => {
+				assert.deepEqual(error, {
+					code: 'rest_forbidden',
+					message: 'Sorry.',
+					data: { status: 403 },
+				});
+				return true;
+			}
+		);
+	});
+
+	it('exposes middleware helpers that run without throwing', async () => {
+		const nonce = apiFetch.createNonceMiddleware('secret');
+		const root = apiFetch.createRootURLMiddleware({
+			url: 'https://wp.example.com/wp-json/',
+		});
+
+		assert.equal(typeof nonce, 'function');
+		assert.equal(typeof root, 'function');
+
+		// Both should call next() and let a request through. The root middleware
+		// sets a url when none is given, the nonce middleware adds the header.
+		apiFetch.use(nonce);
+		apiFetch.use(root);
+
+		await apiFetch({});
+
+		assert.equal(requests[0].url, 'https://wp.example.com/wp-json/');
+		assert.equal(requests[0].options.headers['X-WP-Nonce'], 'secret');
+	});
+});


### PR DESCRIPTION
## Summary
Restores the Statify dashboard widget and the settings reset option on ClassicPress, which no longer ships a working `wp.apiFetch` REST client. ClassicPress has a leftover, broken `wp.apiFetch` object, so after Statify 2.0 the dashboard threw `TypeError: wp.apiFetch is not a function` and stayed empty.

Fixes #363

## Changes
### `js/api-fetch-polyfill.js` (new)
A small, original `wp.apiFetch` subset covering the surface Statify uses: `path`, `url`, `method`, `data`, `headers`, plus the `createRootURLMiddleware`, `createNonceMiddleware` and `use` middleware helpers. Uses `fetch()`, sends the `wp_rest` nonce and JSON bodies, resolves parsed JSON (or `null` on an empty body) and rejects with the REST error shape on failure.

### `inc/class-statify.php`
Adds `Statify::maybe_init_api_fetch_polyfill()`, hooked on `admin_enqueue_scripts` at priority 0. On ClassicPress only (checked via `function_exists( 'classicpress_version' )`) it de-registers the broken core `wp-api-fetch` handle and re-registers the same handle on the plugin polyfill, then localizes the REST root and the `wp_rest` nonce.

Reusing the `wp-api-fetch` handle means `statify_chart_js` and `statify-settings` dependencies keep resolving with no change to the dashboard or settings scripts.

### `package.json`
Adds the polyfill to the `minify:js` and `lint-js` entry lists.

### `tests/js/api-fetch-polyfill.test.js` (new)
Covers URL joining, POST JSON, nonce header on GET and POST, success null/JSON parsing, REST error rejection, and the middleware helpers.

## Testing
**Test 1: ClassicPress dashboard widget**
1. Install the build on a ClassicPress 2.7 site.
2. Open the dashboard.
Result: the Statify widget renders visit data. Before the fix it was empty with a console `TypeError: wp.apiFetch is not a function`.

**Test 2: Console on ClassicPress**
1. After loading the dashboard, open the console.
Result: no `wp.apiFetch.* is not a function` errors.

**Test 3: Settings reset on ClassicPress**
1. Open Settings -> Statify.
2. In the Danger Zone click Reset All Statistics and confirm.
Result: a success or error message appears instead of a silent failure.

**Test 4: Regular WordPress regression**
1. Load the dashboard and reset statistics on a normal WordPress site (5.1+).
Result: behaves exactly as before. The polyfill does not load there.

## Test evidence
Verified manually on ClassicPress 2.7: dashboard shows data and the console is free of the apiFetch TypeError. (`statify-2.0.3-beta-363.zip` will be attached to the release; the fix is the polyfill file plus the `maybe_init_api_fetch_polyfill` method.)

Automated checks are green: `npm run lint-js`, `npm test` (10/10), `composer lint-php`, `composer phpstan`.

## Screenshots
|Before|After|
|-----|-----|
|<img width="960" height="525" alt="SCR-20260824-ohja" src="https://github.com/user-attachments/assets/c9564674-2c6e-4072-8e89-2cf401ee83cd" />|<img width="960" height="525" alt="SCR-20260824-ohof" src="https://github.com/user-attachments/assets/ec5b79a1-63c2-44d8-8be6-66328438af79" />|
