### PR TITLE
fix(settings): localize built-in user role names on settings page

### DIFF
--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -305,7 +305,7 @@ class Statify_Settings {
 				esc_html( $name ),
 				checked( in_array( $role, $saved_roles, true ), true, false )
 			);
-			echo esc_html( $role_object['name'] );
+			echo esc_html( translate_user_role( $role_object['name'] ) );
 			?>
 			</label></p>
 			<?php

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -190,8 +190,8 @@ class Test_Settings extends WP_UnitTestCase {
 			Statify::$options = $original_options;
 		}
 
-		self::assertStringContainsString(
-			'>Redakteur</label>',
+		self::assertMatchesRegularExpression(
+			'/>Redakteur\s*<\/label>/',
 			$html,
 			'built-in role display names should be localized via translate_user_role'
 		);

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -139,4 +139,61 @@ class Test_Settings extends WP_UnitTestCase {
 			'unknown widget roles should have been removed'
 		);
 	}
+
+	/**
+	 * Test localization of built-in user role names in the roles list.
+	 */
+	public function test_show_roles_list_translates_names() {
+		$original_options = Statify::$options;
+
+		Statify::$options = array(
+			'days'              => 14,
+			'days_show'         => 14,
+			'limit'             => 3,
+			'today'             => 0,
+			'snippet'           => 0,
+			'blacklist'         => 0,
+			'show_totals'       => 0,
+			'show_widget_roles' => array( 'editor' ),
+			'skip'              => array(
+				'logged_in' => Statify::SKIP_USERS_ALL,
+			),
+		);
+
+		$roles_callback = static function () {
+			return array(
+				'editor' => array(
+					'name'         => 'Editor',
+					'capabilities' => array(),
+				),
+			);
+		};
+		add_filter( 'statify__available_roles', $roles_callback );
+
+		// Force a translated name for the built-in "Editor" role.
+		$translate_callback = static function ( $translation, $text, $context, $domain ) {
+			if ( 'Editor' === $text && 'User role' === $context && 'default' === $domain ) {
+				return 'Redakteur';
+			}
+
+			return $translation;
+		};
+		add_filter( 'gettext_with_context', $translate_callback, 10, 4 );
+
+		try {
+			ob_start();
+			Statify_Settings::options_show_widget_roles();
+			$html = ob_get_clean();
+		} finally {
+			remove_filter( 'statify__available_roles', $roles_callback );
+			remove_filter( 'gettext_with_context', $translate_callback, 10, 4 );
+			Statify::$options = $original_options;
+		}
+
+		self::assertStringContainsString(
+			'>Redakteur</label>',
+			$html,
+			'built-in role display names should be localized via translate_user_role'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

On the settings page the dashboard widget role list renders the built-in user role names in English even when the site runs in another language. Built-in roles (Administrator, Editor, Author, Contributor, Subscriber) are already translated by WordPress core for the user settings, but Statify outputs the raw stored names.

This change wraps the role display name with WordPress core's `translate_user_role()` so the built-in role names follow the active site language. Custom roles that are not present in the core translation files pass through unchanged, which matches the expected behavior in the issue.

### Before

```php
echo esc_html( $role_object['name'] );
```

### After

```php
echo esc_html( translate_user_role( $role_object['name'] ) );
```

Only the display name changes. The stored role slugs used as the checkbox value and id, the sanitization logic, and the widget visibility checks all keep the English slugs, so nothing about saving or permissions is affected.

### Why

`translate_user_role()` is a core WordPress function, available since WordPress 2.8, and uses the core text domain, so it picks up the translations WordPress already ships for the built-in roles. It is a no-op for custom roles not covered by those translations.

## Test steps

1. Install this branch in a WordPress site set to a non-English locale (for example German).
2. Go to Settings > Statify.
3. Check the dashboard widget role list (last widget option). The built-in role names should now appear translated.
4. Save the settings. Reopen the page. The selected roles are still checked, confirming the stored slugs are unchanged.
5. If a custom role is present, its name stays as defined.

## Screenshots

None. The change is display-only text localization.

Fixes #361