### PR TITLE
fix: show weekday and highlight weekends in dashboard

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -68,11 +68,20 @@
 	color: var(--wp-admin-theme-color-darker-20, #3582c4);
 }
 
+.statify-chart .ct-weekend {
+	fill: var(--wp-admin-theme-color, #3582c4);
+	opacity: 0.14;
+}
+
 
 .statify-table th,
 .statify-table tr.statify-table-sum td,
 .statify-table td.statify-table-sum {
 	font-weight: 700;
+}
+
+.statify-table td.statify-table-weekend {
+	background-color: rgba(0, 0, 0, 0.055);
 }
 
 .statify-table tr.placeholder {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -42,7 +42,8 @@
 		minimumFractionDigits: 2,
 		maximumFractionDigits: 2,
 	});
-	const dateFormatYMD = new Intl.DateTimeFormat(lang, {
+	const dateFormatYMDW = new Intl.DateTimeFormat(lang, {
+		weekday: 'short',
 		year: 'numeric',
 		month: '2-digit',
 		day: '2-digit',
@@ -161,8 +162,12 @@
 				const labels = Object.keys(data.visits);
 				const values = Object.values(data.visits);
 
-				render(charts.dashboard, labels, values, false, (date) =>
-					dateFormatYMD.format(new Date(date))
+				render(
+					charts.dashboard,
+					labels,
+					values,
+					false,
+					formatWeekdayDate
 				);
 
 				// Render top lists.
@@ -254,18 +259,19 @@
 	 *
 	 * @param {HTMLElement}             root Root element.
 	 * @param {{[key: string]: number}} data Data from API.
+	 * @return {Object} The rendered chart.
 	 */
 	function renderDaily(root, data) {
 		const labels = Object.keys(data);
 		const values = Object.values(data);
 		const usedLabels = new Set();
 
-		render(
+		const chart = render(
 			root,
 			labels,
 			values,
 			true,
-			(date) => dateFormatYMD.format(new Date(date)),
+			formatWeekdayDate,
 			(day) => {
 				const date = new Date(day);
 				const mon = date.getMonth();
@@ -276,6 +282,121 @@
 				return dateFormatM.format(date);
 			}
 		);
+
+		highlightWeekendColumns(root, chart, labels);
+
+		return chart;
+	}
+
+	/**
+	 * Parse a date-only string as a local calendar date.
+	 *
+	 * Dates are served as "YYYY-MM-DD" without a timezone. Building a Date
+	 * from the string directly interprets it as UTC, which shifts the day in
+	 * negative-offset regions. Split and rebuild so the local getters match
+	 * the calendar date shown.
+	 *
+	 * @param {string} date Date-only string.
+	 * @return {Date} Local date.
+	 */
+	function parseLocalDate(date) {
+		const [y, m, d] = date.split('-').map(Number);
+		return new Date(y, m - 1, d);
+	}
+
+	/**
+	 * Whether the given date falls on a weekend.
+	 *
+	 * @param {string|Date} date Date-only string or already parsed local date.
+	 * @return {boolean} Whether the date is a Saturday or Sunday.
+	 */
+	function isWeekend(date) {
+		const day = date instanceof Date ? date : parseLocalDate(date);
+		const dow = day.getDay();
+		return 0 === dow || 6 === dow;
+	}
+
+	/**
+	 * Format a date-only string with a weekday prefix.
+	 *
+	 * @param {string} date Date-only string.
+	 * @return {string} Localized weekday and date.
+	 */
+	function formatWeekdayDate(date) {
+		return dateFormatYMDW.format(parseLocalDate(date));
+	}
+
+	/**
+	 * Highlight the weekend columns of a daily chart.
+	 *
+	 * The daily chart is a line chart without native per-column styling, so
+	 * translucent bands are drawn behind the weekend datapoints. Fails silently
+	 * if the Chartist internals change, keeping the weekday labels intact.
+	 *
+	 * @param {HTMLElement} root   Root element of the chart.
+	 * @param {Object}      chart  Chart to enhance.
+	 * @param {string[]}    labels ISO date labels in chart order.
+	 */
+	function highlightWeekendColumns(root, chart, labels) {
+		if (!chart) {
+			return;
+		}
+
+		try {
+			// Collect the x position of every weekend datapoint.
+			const xs = [];
+			chart.on('draw', (d) => {
+				if ('point' !== d.type) {
+					return;
+				}
+				if (isWeekend(labels[d.index])) {
+					xs.push(d.x);
+				}
+			});
+
+			// Insert a translucent band behind each weekend column once the SVG is laid out.
+			chart.on('created', (t) => {
+				const rect = t.chartRect;
+				if (!rect || 0 === xs.length) {
+					return;
+				}
+
+				const svg =
+					root.querySelector('.ct-chart-line') ||
+					root.querySelector('svg');
+				if (!svg) {
+					return;
+				}
+
+				// Insert before the first series so the bands layer behind the datapoints.
+				const series = svg.querySelector('.ct-series');
+
+				const band =
+					xs.length > 1 && xs[1] !== xs[0]
+						? Math.round((xs[1] - xs[0]) * 0.5)
+						: Math.round(rect.width * 0.012);
+
+				xs.forEach((x) => {
+					const rectEl = new Chartist.Svg(
+						'rect',
+						{
+							x: Math.round(x - band / 2),
+							y: rect.y1,
+							width: band,
+							height: Math.max(rect.height, 1),
+						},
+						'ct-weekend'
+					)._node;
+					if (series) {
+						svg.insertBefore(rectEl, series);
+					} else {
+						svg.appendChild(rectEl);
+					}
+				});
+			});
+		} catch {
+			// Weekend highlight is decorative, ignore on failure.
+		}
 	}
 
 	/**
@@ -351,6 +472,7 @@
 	/**
 	 * Render statistics chart.
 	 *
+	 * @return {Object|undefined} The rendered chart, or undefined when no data.
 	 * @param {HTMLElement}             root                  Root element.
 	 * @param {string[]}                labels                Labels.
 	 * @param {number[]}                values                Values.
@@ -463,6 +585,8 @@
 				d.element.replace(circle);
 			}
 		});
+
+		return chart;
 	}
 
 	/**
@@ -617,7 +741,7 @@
 		col.textContent = wp.i18n.sprintf(
 			/* translators: %s: Date. */
 			wp.i18n.__('since %s', 'statify'),
-			dateFormatYMD.format(new Date(data.since))
+			formatWeekdayDate(data.since)
 		);
 		rowAll.appendChild(col);
 
@@ -681,20 +805,27 @@
 		const cols = rows.map((row) => Array.from(row.querySelectorAll('td')));
 		let out = cols.slice(0, 31);
 
+		// Clear weekend highlights from cells and collect the month columns.
+		const cells = cols.flat();
+		cells.forEach((cell) => cell.classList.remove('statify-table-weekend'));
 		const sum = new Array(12).fill(0);
 		const vls = new Array(12).fill(0);
 		const min = new Array(12).fill(Number.MAX_SAFE_INTEGER);
 		const max = new Array(12).fill(0);
 
 		for (const [day, count] of Object.entries(data)) {
-			const d = new Date(day);
+			const d = parseLocalDate(day);
 			const m = d.getMonth();
 			sum[m] += count;
 			++vls[m];
 			min[m] = Math.min(min[m], count);
 			max[m] = Math.max(max[m], count);
-			out[d.getDate() - 1][m].dataset.raw = String(count);
-			out[d.getDate() - 1][m].textContent = numberFormat.format(count);
+			const cell = out[d.getDate() - 1][m];
+			cell.dataset.raw = String(count);
+			cell.textContent = numberFormat.format(count);
+			if (isWeekend(d)) {
+				cell.classList.add('statify-table-weekend');
+			}
 		}
 
 		out =

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 ## Changelog ##
 You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
 
+### Unreleased
+* Show the weekday in date labels and highlight weekend days in the dashboard (#284)
+
 ### 2.0.2
 * Translatable texts in JS-generated content now work as expected
 * Special characters in post titles are now displayed correctly


### PR DESCRIPTION
## Summary
Show the weekday before dates in the dashboard and tint weekend days so they are easier to scan. Reads better and matches the ask in #284 for more info on views.

Fixes #284

## Changes
### Date labels
Formats single daily dates with the weekday included, e.g. "Sat, 08/02/2026". Applies to the dashboard widget chart tooltip, the daily overview chart tooltip, and the totals "since ..." row.

### Weekend highlight on the daily chart
Weekend columns get a translucent background band on the daily overview chart. The chart has no per-column hook, so positions are collected on draw and thin rects are inserted behind the series on created. If a future Chartist change breaks the band, it fails silently and only the tint is lost, the weekday labels still work.

### Weekend highlight on the monthly table
Saturday and Sunday day cells are tinted in the "Daily Views" table. Re-renders clear old highlights so switching month/year leaves no stale tint.

### Timezone safety
Date-only strings (e.g. "2024-02-10") are now parsed as local calendar dates instead of UTC midnight. This keeps weekday detection and the tint correct in negative UTC offset regions (the previous parse could shift the day).

## Testing
**Test 1: Weekday on chart tooltips**
1. Open the Statify dashboard or dashboard widget.
2. Hover a data point on the daily chart.
3. Result: tooltip shows the weekday before the date, e.g. "Sat, 08/02/2026".

**Test 2: Weekend bands on the daily chart**
1. Open the daily overview chart.
2. Look at Saturday and Sunday columns.
3. Result: weekend columns show a subtle translucent band.

**Test 3: Weekend cells in the monthly table**
1. Open the extended daily view table.
2. Check day cells for weekends.
3. Result: Saturday and Sunday cells are tinted, weekdays are not.
4. Switch month/year. Result: old highlights clear, correct cells apply for the new month.

**Test 4: Totals row**
1. Check the totals line in the dashboard.
2. Result: reads "since Fri, 01/01/2026" (weekday + date).

## Screenshots
No screenshots (visual, confirmed manually during testing).
