### PR TITLE
docs: explain missing sources in dashboard widget (#307)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,18 @@ If you've problems or think you’ve found a bug (e.g. you’re experiencing une
 
 This behavior can be modified with the `statify__skip_tracking` hook.
 
+### Why are some sources missing in the dashboard widget? ###
+*Statify* determines the source of a visit from the [Referer](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Referer) request header (or, with JavaScript tracking enabled, from `document.referrer`). The browser only sends this information when the originating site allows it via the [`Referrer-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Referrer-Policy) header, so the originating site controls whether Statify receives a source at all.
+
+A few common reasons why a Referer is missing:
+
+* the originating site sends `Referrer-Policy: no-referrer` or `same-origin` (the latter is the default on many Fediverse instances, including Mastodon)
+* the link uses `rel="noreferrer"` or `rel="noopener noreferrer"`
+* the link goes from an HTTPS page to an HTTP page, which most browsers strip
+* the visitor uses a browser extension that suppresses Referer headers
+
+When the browser does not send a Referer, *Statify* has no data to record. There is no workaround on the receiving end, because the privacy decision is made by the browser on the originating site. If you are linking from your own site and want the link to be tracked, use a plain `<a href="…">` link without `rel="noreferrer"`.
+
 ### Can further visitor data be recorded? ###
 Some plugin users want to capture additional visitor data, e.g. name of the device and resolution.
 *Statify* counts exclusively page views and no visitors, the desired data acquisition is not a question.


### PR DESCRIPTION
## Summary
Added a FAQ entry to the plugin readme explaining why some referrer sources can be missing in the dashboard widget. Statify reads the source of a visit from the Referer header (or from `document.referrer` when JavaScript tracking is enabled). Both are controlled by the `Referrer-Policy` header of the originating site, so a missing source is caused by the browser or by the privacy policy of the referring site, not by Statify.

Fixes #307

## Changes
### readme.txt
Added a new FAQ item "Why are some sources missing in the dashboard widget?" between the existing "Which areas are excluded from counting?" and "Can further visitor data be recorded?" entries.

The entry lists the common reasons a Referer can be missing:

* the originating site sends `Referrer-Policy: no-referrer` or `same-origin` (the latter is the default on many Fediverse instances, including Mastodon)
* the link uses `rel="noreferrer"` or `rel="noopener noreferrer"`
* the link goes from an HTTPS page to an HTTP page
* the visitor uses a browser extension that suppresses Referer headers

It links to the Mozilla documentation for the [Referer](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Referer) header and the [`Referrer-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Referrer-Policy) header, and states plainly that there is no workaround on the receiving end when the browser does not send the referer.

**Why:** Users report missing sources as a bug, but the data is simply never sent by the browser for certain origins. Documenting the behavior sets the right expectations and reduces duplicate support reports. No application code is changed.

## Testing
**Test 1: Readme renders correctly**
1. Open the modified `readme.txt`.
2. Confirm the FAQ section reads coherently: heading, plain-language paragraph, bullet list, closing note, then the next heading "Can further visitor data be recorded?".
Result: works as expected, no broken structure.

**Test 2: No regression**
1. Confirm the diff touches `readme.txt` only.
Result: works as expected, no functional change.

## Screenshots
No UI changes, so no screenshots.