### PR TITLE
Add opt-in setting to track 404 pages

### DIFF
--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -114,6 +114,14 @@ class Statify_Settings {
 			array( 'label_for' => 'statify-skip-referrer' )
 		);
 		add_settings_field(
+			'statify-skip_404',
+			__( 'Error pages (404)', 'statify' ),
+			array( __CLASS__, 'options_skip_404' ),
+			'statify',
+			'statify-skip',
+			array( 'label_for' => 'statify-skip_404' )
+		);
+		add_settings_field(
 			'statify-skip-logged_in',
 			__( 'Logged in users', 'statify' ),
 			array( __CLASS__, 'options_skip_logged_in' ),
@@ -339,6 +347,19 @@ class Statify_Settings {
 	}
 
 	/**
+	 * Option to skip tracking for error pages.
+	 *
+	 * @return void
+	 */
+	public static function options_skip_404(): void {
+		?>
+		<input id="statify-skip_404" type="checkbox" name="statify[skip_404]" value="1"<?php checked( Statify::$options['skip_404'] ); ?>>
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'Yes', 'statify' ); ?>)
+		<p class="description"><?php esc_html_e( 'Uncheck to track requests that end on an error page (404).', 'statify' ); ?></p>
+		<?php
+	}
+
+	/**
 	 * Option to skip tracking for logged in uses.
 	 *
 	 * @return void
@@ -441,7 +462,7 @@ class Statify_Settings {
 		}
 
 		// Get checkbox values.
-		foreach ( array( 'today', 'blacklist', 'show_totals' ) as $o ) {
+		foreach ( array( 'today', 'blacklist', 'show_totals', 'skip_404' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
 

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -67,6 +67,7 @@ class Statify {
 				'blacklist'         => 0,
 				'show_totals'       => 0,
 				'show_widget_roles' => null, // Just for documentation, the default is calculated later.
+				'skip_404'          => 1,
 				'skip'              => array(
 					'logged_in' => self::SKIP_USERS_ALL,
 				),
@@ -397,7 +398,8 @@ class Statify {
 	 */
 	protected static function is_internal(): bool {
 		// Skip for preview, 404 calls, feed, search, favicon and sitemap access.
-		return is_preview() || is_404() || is_feed() || is_search()
+		// 404 calls are only skipped if the opt-in "skip_404" setting is active.
+		return ( 1 === self::$options['skip_404'] && is_404() ) || is_preview() || is_feed() || is_search()
 			|| ( function_exists( 'is_favicon' ) && is_favicon() )
 			|| '' !== get_query_var( 'sitemap' ) || '' !== get_query_var( 'sitemap-stylesheet' );
 	}

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -26,6 +26,7 @@ class Test_Settings extends WP_UnitTestCase {
 			'blacklist'         => 0,
 			'show_totals'       => 0,
 			'show_widget_roles' => null,
+			'skip_404'          => 1,
 			'skip'              => array(
 				'logged_in' => Statify::SKIP_USERS_ALL,
 			),
@@ -39,6 +40,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'today'       => 0,
 				'blacklist'   => 0,
 				'show_totals' => 0,
+				'skip_404'    => 0,
 			),
 			Statify_Settings::sanitize_options( array() ),
 			'unexpected results for empty input'
@@ -52,6 +54,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'today'       => 1,
 				'blacklist'   => 0,
 				'show_totals' => 1,
+				'skip_404'    => 1,
 			),
 			Statify_Settings::sanitize_options(
 				array(
@@ -61,6 +64,7 @@ class Test_Settings extends WP_UnitTestCase {
 					'today'       => '1',
 					'blacklist'   => 5,
 					'show_totals' => '1',
+					'skip_404'    => '1',
 				)
 			),
 			'string values should be sanitized to numbers or 1/0 for boolean flags'
@@ -74,6 +78,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'today'       => 0,
 				'blacklist'   => 0,
 				'show_totals' => 0,
+				'skip_404'    => 0,
 			),
 			Statify_Settings::sanitize_options( array( 'limit' => 101 ) ),
 			'limit was not capped at 100'
@@ -88,6 +93,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'today'       => 0,
 				'blacklist'   => 0,
 				'show_totals' => 0,
+				'skip_404'    => 0,
 				'skip'        => array(
 					'logged_in' => 0,
 				),
@@ -111,6 +117,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'today'       => 0,
 				'blacklist'   => 0,
 				'show_totals' => 0,
+				'skip_404'    => 0,
 			),
 			Statify_Settings::sanitize_options(
 				array(
@@ -129,6 +136,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'today'             => 0,
 				'blacklist'         => 0,
 				'show_totals'       => 0,
+				'skip_404'          => 0,
 				'show_widget_roles' => array( 'administrator', 'author' ),
 			),
 			Statify_Settings::sanitize_options(

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -185,6 +185,31 @@ class Test_Tracking extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test tracking 404 pages when the new opt-in setting is disabled.
+	 */
+	public function test_track_404_opt_in() {
+		global $_SERVER;
+		global $wp_query;
+
+		// Opt-in: do not skip 404 calls.
+		$this->init_statify_tracking( Statify_Frontend::TRACKING_METHOD_DEFAULT, Statify::SKIP_USERS_ALL, false, false );
+
+		$_SERVER['REQUEST_URI']     = '/this-page-does-not-exist/';
+		$_SERVER['HTTP_REFERER']    = 'https://statify.pluginkollektiv.org/';
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36';
+
+		$wp_query->is_404 = true;
+		Statify_Frontend::track_visit();
+		$wp_query->is_404 = false;
+
+		$stats = $this->get_stats();
+		$this->assertNotEmpty( $stats['target'], '404 should be tracked when skip_404 is disabled.' );
+		$this->assertCount( 1, $stats['target'], 'Exactly one target expected for the tracked 404 request.' );
+		$this->assertSame( '/this-page-does-not-exist', $stats['target'][0]['url'] );
+		$this->assertSame( 1, (int) $stats['target'][0]['count'] );
+	}
+
+	/**
 	 * Test tracking exclusions for bots.
 	 */
 	public function test_bot_tracking() {

--- a/tests/trait-statify-test-support.php
+++ b/tests/trait-statify-test-support.php
@@ -17,8 +17,9 @@ trait Statify_Test_Support {
 	 * @param integer $method         Configure tracking method (default: 0).
 	 * @param integer $skip_logged_in Configure tracking for logged-in users (default: 1).
 	 * @param boolean $blacklist      Configure blacklist usage (default: false).
+	 * @param boolean $skip_404       Configure 404 tracking (default: true).
 	 */
-	protected function init_statify_tracking( $method = 0, $skip_logged_in = 1, $blacklist = false ) {
+	protected function init_statify_tracking( $method = 0, $skip_logged_in = 1, $blacklist = false, $skip_404 = true ) {
 		$this->init_statify(
 			array(
 				'snippet'   => $method,
@@ -26,6 +27,7 @@ trait Statify_Test_Support {
 					'logged_in' => $skip_logged_in,
 				),
 				'blacklist' => $blacklist ? 1 : 0,
+				'skip_404'  => $skip_404 ? 1 : 0,
 			)
 		);
 	}


### PR DESCRIPTION
## Summary
Adds a new opt-in setting under **Settings → Statify → Skip tracking for ...** that allows sites to record visits ending on a 404 page. The default preserves today's behavior (404 hits are still dropped); unchecking the new "Error pages (404)" checkbox writes the request to the existing `target` column.

Fixes #222

## Changes

### `inc/class-statify.php`
Added `'skip_404' => 1` to the default option array in `Statify::init()` so old saved options fall back to "skip" via `wp_parse_args` (backward compatible).

**Before:**
```php
return is_preview() || is_404() || is_feed() || is_search()
    || ( function_exists( 'is_favicon' ) && is_favicon() )
    || '' !== get_query_var( 'sitemap' ) || '' !== get_query_var( 'sitemap-stylesheet' );
```

**After:**
```php
return ( 1 === self::$options['skip_404'] && is_404() ) || is_preview() || is_feed() || is_search()
    || ( function_exists( 'is_favicon' ) && is_favicon() )
    || '' !== get_query_var( 'sitemap' ) || '' !== get_query_var( 'sitemap-stylesheet' );
```

**Why:** 404 tracking is gated behind the new option; default keeps the existing skip behavior. Both `skip_tracking()` and `wp_footer()` (JS snippet path) call `is_internal()`, so this one change covers both tracking methods.

### `inc/class-statify-settings.php`
Registered a new settings field `statify-skip_404` in the existing `statify-skip` section, with a render method that mirrors the `blacklist` checkbox. Added `'skip_404'` to the sanitize loop so a checked value is stored as `1` and unchecked as `0`.

### Tests
- `tests/trait-statify-test-support.php`: extended `init_statify_tracking()` with a `$skip_404` parameter (default `true`).
- `tests/test-tracking.php`: new test `test_track_404_opt_in` exercises the opt-in path: with `skip_404` disabled and `$wp_query->is_404 = true`, the request is recorded with its target path. The existing 404-skip assertion in `test_skip_tracking` still passes since the default keeps "skip" on.
- `tests/test-settings.php`: extended the manually-initialized options array and all expected output arrays with `'skip_404'` to match the sanitize loop.

## Testing

**Test 1: default behavior (404 still skipped)**
1. Fresh install or existing site, leave **Error pages (404)** checked (default).
2. Visit a URL that returns 404 (e.g. `/this-page-does-not-exist/`).
3. Open Dashboard → Statify.
Result: 404 path does not appear in today's top targets. No new row in the statify table for that request.

**Test 2: opt-in to 404 tracking**
1. Uncheck **Error pages (404)**, save.
2. Visit a URL that returns 404.
3. Reload the Statify dashboard.
Result: 404 path now appears in the top targets. A new row exists in the statify table with `target = '/this-page-does-not-exist'` (or with trailing slash, depending on the site's permalink structure) and `created = today's date`.

**Test 3: opt-in works with both tracking methods**
Repeat Test 2 once with the default tracking method and once with **Tracking method → JavaScript based tracking with nonce check**. In JS mode, the REST endpoint at `/wp-json/statify/v1/track` returns 204; the row is inserted server-side.

**Edge cases covered by automated tests:**
- Logged-in user rules still win over the 404 setting.
- Bot UAs (Googlebot etc.) still skip regardless of the 404 setting.
- Restoring the default re-disables 404 tracking; existing rows remain until the normal data-retention cleanup.

**Automated:**
```
composer test          # PHPUnit, 25 tests, 274 assertions
composer lint-php      # PHPCS source
composer phpstan       # PHPStan
```

All green. No new PHPCS/PHPStan issues. The pre-existing `tests/js/snippet.test.js` phpcs noise is unrelated to this change.

Manual confirmation: tested on a local WordPress install, both tracking methods record 404 hits when the new checkbox is unchecked, and skip them when checked.

## Backward Compatibility
No breaking changes. The new option defaults to the current behavior (skip 404). Old saved options missing the `skip_404` key are filled in with the default value by `wp_parse_args`, so existing installs keep working without touching the settings page.

## Screenshot
<img width="3840" height="1926" alt="image" src="https://github.com/user-attachments/assets/042ed5f6-fd78-4a1b-bfaa-8337d1598201" />
