### PR TITLE
Add opt-in auto-refresh for dashboard widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.3
+
+### Features
+
+* Add opt-in auto-refresh for the dashboard widget chart and lists. Once enabled under Settings > Statify, the chart and top lists update every 15 minutes while the dashboard tab is visible, and immediately on focus or returning to the tab (#267)
+
+
 ## 2.0.2
 
 ### Fixes

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -97,6 +97,14 @@ class Statify_Settings {
 			'statify',
 			'statify-dashboard'
 		);
+		add_settings_field(
+			'statify-auto-refresh',
+			__( 'Auto-refresh dashboard widget', 'statify' ),
+			array( __CLASS__, 'options_auto_refresh' ),
+			'statify',
+			'statify-dashboard',
+			array( 'label_for' => 'statify-auto-refresh' )
+		);
 
 		// Exclusion settings.
 		add_settings_section(
@@ -251,6 +259,19 @@ class Statify_Settings {
 	public static function options_show_totals(): void {
 		?>
 		<input  id="statify-show-totals" type="checkbox" name="statify[show_totals]" value="1" <?php checked( Statify::$options['show_totals'], 1 ); ?>>
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
+		<?php
+	}
+
+	/**
+	 * Option for automatically refreshing the dashboard widget.
+	 *
+	 * @return void
+	 */
+	public static function options_auto_refresh(): void {
+		?>
+		<input id="statify-auto-refresh" type="checkbox" name="statify[auto_refresh]" value="1" <?php checked( Statify::$options['auto_refresh'], 1 ); ?>>
+		<p class="description"><?php esc_html_e( 'Automatically update the chart and lists while the dashboard is open.', 'statify' ); ?></p>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
 		<?php
 	}
@@ -441,7 +462,7 @@ class Statify_Settings {
 		}
 
 		// Get checkbox values.
-		foreach ( array( 'today', 'blacklist', 'show_totals' ) as $o ) {
+		foreach ( array( 'today', 'blacklist', 'auto_refresh', 'show_totals' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
 

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -65,6 +65,7 @@ class Statify {
 				'today'             => 0,
 				'snippet'           => 0,
 				'blacklist'         => 0,
+				'auto_refresh'      => 0,
 				'show_totals'       => 0,
 				'show_widget_roles' => null, // Just for documentation, the default is calculated later.
 				'skip'              => array(
@@ -259,9 +260,16 @@ class Statify {
 			true
 		);
 		wp_register_script(
+			'statify_auto_refresh_js',
+			plugins_url( 'js/auto-refresh.min.js', STATIFY_FILE ),
+			array(),
+			self::get_version(),
+			true
+		);
+		wp_register_script(
 			'statify_chart_js',
 			plugins_url( 'js/dashboard.min.js', STATIFY_FILE ),
-			array( 'wp-api-fetch', 'chartist_tooltip_js' ),
+			array( 'wp-api-fetch', 'chartist_tooltip_js', 'statify_auto_refresh_js' ),
 			self::get_version(),
 			true
 		);
@@ -271,7 +279,8 @@ class Statify {
 			'statify_chart_js',
 			'statifyDashboard',
 			array(
-				'sitename' => sanitize_key( get_bloginfo( 'name' ) ),
+				'sitename'    => sanitize_key( get_bloginfo( 'name' ) ),
+				'autoRefresh' => (bool) self::$options['auto_refresh'],
 			)
 		);
 		wp_set_script_translations( 'statify_chart_js', 'statify' );

--- a/js/auto-refresh.js
+++ b/js/auto-refresh.js
@@ -1,0 +1,57 @@
+/**
+ * Auto-refresh supervisor.
+ *
+ * Runs a periodic callback and exposes start/stop hooks. The callback may
+ * return a Promise; rejections are swallowed so the next tick still fires.
+ *
+ * Exposed as a global `statifyAutoRefresh` in the browser and as
+ * `module.exports` under node:test.
+ * @param root
+ * @param factory
+ */
+(function (root, factory) {
+	const api = factory();
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = api;
+	} else {
+		root.statifyAutoRefresh = api;
+	}
+})(typeof self !== 'undefined' ? self : this, function () {
+	/**
+	 * Create an auto-refresh supervisor.
+	 *
+	 * @param {Object}   options            Configuration.
+	 * @param {number}   options.intervalMs Interval in milliseconds.
+	 * @param {Function} options.refresh    Callback. May return a Promise.
+	 * @return {{start: Function, stop: Function}} Supervisor instance.
+	 */
+	function createAutoRefresh(options) {
+		const intervalMs = options.intervalMs;
+		const refresh = options.refresh;
+		let handle = null;
+
+		function tick() {
+			Promise.resolve()
+				.then(refresh)
+				.catch(function () {
+					/* keep the timer alive on error */
+				});
+		}
+
+		function start() {
+			stop();
+			handle = setInterval(tick, intervalMs);
+		}
+
+		function stop() {
+			if (handle !== null) {
+				clearInterval(handle);
+				handle = null;
+			}
+		}
+
+		return { start, stop };
+	}
+
+	return { createAutoRefresh };
+});

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -898,6 +898,33 @@
 	if (charts.dashboard) {
 		// Initial update.
 		updateDashboard(false);
+
+		// Optional auto-refresh while the tab is visible.
+		if (statifyDashboard.autoRefresh) {
+			const refreshIntervalMs = 15 * 60 * 1000;
+			const autoRefresh = statifyAutoRefresh.createAutoRefresh({
+				intervalMs: refreshIntervalMs,
+				refresh: () => updateDashboard(true),
+			});
+
+			if (!document.hidden) {
+				autoRefresh.start();
+			}
+
+			document.addEventListener('visibilitychange', () => {
+				if (document.hidden) {
+					autoRefresh.stop();
+				} else {
+					autoRefresh.start();
+					updateDashboard(true);
+				}
+			});
+
+			window.addEventListener('focus', () => {
+				autoRefresh.start();
+				updateDashboard(true);
+			});
+		}
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "copy-assets": "vendor-copy",
     "minify": "npm run minify:js && npm run minify:css",
     "minify:css": "esbuild css/dashboard.css css/settings.css --minify --outdir=css --outbase=. --entry-names=[name].min",
-    "minify:js": "esbuild js/dashboard.js js/settings.js js/snippet.js --minify --outdir=js --outbase=js --entry-names=[name].min",
+    "minify:js": "esbuild js/auto-refresh.js js/dashboard.js js/settings.js js/snippet.js --minify --outdir=js --outbase=js --entry-names=[name].min",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-css": "stylelint css/dashboard.css css/settings.css",
-    "lint-js": "eslint js/dashboard.js js/settings.js js/snippet.js",
+    "lint-js": "eslint js/auto-refresh.js js/dashboard.js js/settings.js js/snippet.js",
     "test": "nyc --reporter=text node --test tests/js/*.test.js"
   },
   "vendorCopy": [

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Requires at least: 5.1
 * Tested up to:      7.0
 * Requires PHP:      7.4
-* Stable tag:        2.0.2
+* Stable tag:        2.0.3
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -119,6 +119,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 ## Changelog ##
 You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
+
+### 2.0.3
+* Add opt-in auto-refresh for the dashboard widget chart and lists
 
 ### 2.0.2
 * Translatable texts in JS-generated content now work as expected

--- a/statify.php
+++ b/statify.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Statify
  * Plugin URI:        https://statify.pluginkollektiv.org/
  * Description:       Compact, easy-to-use and privacy-compliant stats plugin for WordPress.
- * Version:           2.0.2
+ * Version:           2.0.3
  * Requires at least: 5.1
  * Requires PHP:      7.4
  * Author:            pluginkollektiv
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'STATIFY_FILE', __FILE__ );
 define( 'STATIFY_DIR', __DIR__ );
 define( 'STATIFY_BASE', plugin_basename( __FILE__ ) );
-define( 'STATIFY_VERSION', '2.0.2' );
+define( 'STATIFY_VERSION', '2.0.3' );
 
 /* Hooks */
 add_action( 'plugins_loaded', array( 'Statify', 'init' ) );

--- a/tests/js/auto-refresh.test.js
+++ b/tests/js/auto-refresh.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for the auto-refresh supervisor.
+ *
+ * @package Statify
+ */
+
+const { describe, it } = require( 'node:test' );
+const assert                   = require( 'node:assert/strict' );
+
+const { createAutoRefresh } = require( '../../js/auto-refresh.js' );
+
+const tick = ( ms ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+
+describe( 'Statify Auto-Refresh', () => {
+	it( 'start() calls refresh on every interval tick', async () => {
+		let calls = 0;
+		const sup = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+				},
+			}
+		);
+
+		sup.start();
+		assert.equal( calls, 0, 'refresh not called before first tick' );
+
+		await tick( 35 );
+		sup.stop();
+		assert.ok(
+			calls >= 2,
+			'refresh fired at least twice (' + calls + ')'
+		);
+	} );
+
+	it( 'stop() prevents further refresh calls', async () => {
+		let calls   = 0;
+		let stopped = 0;
+		const sup   = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+				},
+			}
+		);
+
+		sup.start();
+		await tick( 25 );
+		sup.stop();
+		stopped = calls;
+		await tick( 25 );
+		assert.equal( calls, stopped, 'no calls after stop()' );
+	} );
+
+	it( 'a rejected refresh does not throw and does not stop the timer', async () => {
+		let calls = 0;
+		const sup = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+					if ( calls === 1 ) {
+						return Promise.reject( new Error( 'boom' ) );
+					}
+					return undefined;
+				},
+			}
+		);
+
+		sup.start();
+		await tick( 35 );
+		sup.stop();
+		assert.ok(
+			calls >= 2,
+			'timer survived rejection (' + calls + ' calls)'
+		);
+	} );
+
+	it( 'start() resets a previous timer', async () => {
+		let calls = 0;
+		const sup = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+				},
+			}
+		);
+
+		sup.start();
+		sup.start();
+		sup.start();
+		await tick( 25 );
+		sup.stop();
+		assert.ok(
+			calls >= 1 && calls <= 4,
+			'single active timer (' + calls + ' calls)'
+		);
+	} );
+} );

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -24,6 +24,7 @@ class Test_Settings extends WP_UnitTestCase {
 			'today'             => 0,
 			'snippet'           => 0,
 			'blacklist'         => 0,
+			'auto_refresh'      => 0,
 			'show_totals'       => 0,
 			'show_widget_roles' => null,
 			'skip'              => array(
@@ -33,12 +34,13 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 3,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
 			),
 			Statify_Settings::sanitize_options( array() ),
 			'unexpected results for empty input'
@@ -46,21 +48,23 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 15,
-				'days_show'   => 13,
-				'limit'       => 4,
-				'today'       => 1,
-				'blacklist'   => 0,
-				'show_totals' => 1,
+				'days'         => 15,
+				'days_show'    => 13,
+				'limit'        => 4,
+				'today'        => 1,
+				'blacklist'    => 0,
+				'auto_refresh' => 1,
+				'show_totals'  => 1,
 			),
 			Statify_Settings::sanitize_options(
 				array(
-					'days'        => '15',
-					'days_show'   => '13',
-					'limit'       => '4',
-					'today'       => '1',
-					'blacklist'   => 5,
-					'show_totals' => '1',
+					'days'         => '15',
+					'days_show'    => '13',
+					'limit'        => '4',
+					'today'        => '1',
+					'blacklist'    => 5,
+					'auto_refresh' => '1',
+					'show_totals'  => '1',
 				)
 			),
 			'string values should be sanitized to numbers or 1/0 for boolean flags'
@@ -68,12 +72,13 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 100,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 100,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
 			),
 			Statify_Settings::sanitize_options( array( 'limit' => 101 ) ),
 			'limit was not capped at 100'
@@ -81,14 +86,15 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 3,
-				'snippet'     => 1,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
-				'skip'        => array(
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'snippet'      => 1,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
+				'skip'         => array(
 					'logged_in' => 0,
 				),
 			),
@@ -105,12 +111,13 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 3,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
 			),
 			Statify_Settings::sanitize_options(
 				array(
@@ -128,6 +135,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'limit'             => 3,
 				'today'             => 0,
 				'blacklist'         => 0,
+				'auto_refresh'      => 0,
 				'show_totals'       => 0,
 				'show_widget_roles' => array( 'administrator', 'author' ),
 			),
@@ -137,6 +145,24 @@ class Test_Settings extends WP_UnitTestCase {
 				)
 			),
 			'unknown widget roles should have been removed'
+		);
+
+		self::assertSame(
+			array(
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
+			),
+			Statify_Settings::sanitize_options(
+				array(
+					'auto_refresh' => '2',
+				)
+			),
+			'bogus auto_refresh value should be coerced to 0'
 		);
 	}
 }

--- a/tests/test-statify.php
+++ b/tests/test-statify.php
@@ -52,4 +52,42 @@ class Test_Statify extends WP_UnitTestCase {
 		);
 		self::assertFalse( Statify::user_can_see_stats(), 'Anonymous must not see stats with hook override' );
 	}
+
+	/**
+	 * Test that the dashboard script localize payload exposes the auto-refresh flag.
+	 */
+	public function test_localize_auto_refresh() {
+		// Default: option absent => autoRefresh false.
+		Statify::$options['auto_refresh'] = 0;
+		Statify::add_js();
+		$registered = wp_scripts()->registered['statify_chart_js'] ?? null;
+		self::assertNotNull( $registered, 'statify_chart_js should be registered' );
+		$extra_data = $registered->extra['data'] ?? '';
+		self::assertNotEmpty( $extra_data, 'extra[data] should be set after add_js' );
+		self::assertStringContainsString( 'statifyDashboard', $extra_data, 'localize var should be present' );
+		preg_match( '/var\s+statifyDashboard\s*=\s*(\{.*?\});/', $extra_data, $matches );
+		self::assertArrayHasKey( 1, $matches, 'statifyDashboard object should be in data' );
+		$payload = json_decode( $matches[1], true );
+		self::assertIsArray( $payload, 'localized payload should decode to an array' );
+		self::assertArrayHasKey( 'autoRefresh', $payload, 'autoRefresh key should be present' );
+		// wp_localize_script casts booleans to strings ('1'/''), so we
+		// assert on the JS-side truthy/falsy semantics rather than the
+		// PHP value type.
+		self::assertEmpty( $payload['autoRefresh'], 'autoRefresh should be falsy when option is off' );
+
+		// Reset for second pass.
+		wp_deregister_script( 'statify_chart_js' );
+
+		// Enabled: option set => autoRefresh true.
+		Statify::$options['auto_refresh'] = 1;
+		Statify::add_js();
+		$registered = wp_scripts()->registered['statify_chart_js'] ?? null;
+		self::assertNotNull( $registered, 'statify_chart_js should be registered when enabled' );
+		$extra_data = $registered->extra['data'] ?? '';
+		self::assertNotEmpty( $extra_data, 'extra[data] should be set when enabled' );
+		preg_match( '/var\s+statifyDashboard\s*=\s*(\{.*?\});/', $extra_data, $matches );
+		self::assertArrayHasKey( 1, $matches, 'statifyDashboard object should be in data when enabled' );
+		$payload = json_decode( $matches[1], true );
+		self::assertNotEmpty( $payload['autoRefresh'], 'autoRefresh should be truthy when option is on' );
+	}
 }


### PR DESCRIPTION
## Summary

Adds an opt-in auto-refresh for the Statify dashboard widget chart and top lists. Today the widget fetches statistics once on page load (a 15-minute `statify_data` transient caches the response) and never updates until the user reloads the page. This change lets the widget refresh itself while the tab is visible.

The feature defaults to off, so existing installs are unaffected. When enabled, the dashboard tab refreshes its chart and lists every 15 minutes while visible, immediately on window focus, and immediately when the tab returns from a hidden state. The timer pauses on `visibilitychange` hidden, and refresh failures are swallowed so the next tick still fires.

Fixes #267

## Changes

### New `js/auto-refresh.js`
A small UMD module exposing `createAutoRefresh({ intervalMs, refresh })` returning `{ start, stop }`. No DOM access, so it is unit-testable under node:test.

### `inc/class-statify.php`
Registers a `statify_auto_refresh_js` handle, adds it as a dependency of `statify_chart_js`, and localizes `autoRefresh` on the existing `statifyDashboard` object.

**Before:**
```php
wp_register_script(
    'statify_chart_js',
    plugins_url( 'js/dashboard.min.js', STATIFY_FILE ),
    array( 'wp-api-fetch', 'chartist_tooltip_js' ),
    self::get_version(),
    true
);
```

**After:**
```php
wp_register_script(
    'statify_auto_refresh_js',
    plugins_url( 'js/auto-refresh.min.js', STATIFY_FILE ),
    array(),
    self::get_version(),
    true
);
wp_register_script(
    'statify_chart_js',
    plugins_url( 'js/dashboard.min.js', STATIFY_FILE ),
    array( 'wp-api-fetch', 'chartist_tooltip_js', 'statify_auto_refresh_js' ),
    self::get_version(),
    true
);
```
**Why:** the auto-refresh helper must load before `dashboard.js` uses it.

### `inc/class-statify-settings.php`
Adds an "Auto-refresh dashboard widget" checkbox in the statify-dashboard section, an `options_auto_refresh()` renderer mirroring `options_today()`, and `'auto_refresh'` in the existing checkbox sanitize loop so the value is forced to `0` or `1`.

### `js/dashboard.js`
Arms the supervisor only when `charts.dashboard` exists and `statifyDashboard.autoRefresh` is truthy, so the new code is inert on evaluation pages and when the setting is off.

**Before:**
```js
if (charts.dashboard) {
    updateDashboard(false);
}
```

**After:**
```js
if (charts.dashboard) {
    updateDashboard(false);

    if (statifyDashboard.autoRefresh) {
        const autoRefresh = statifyAutoRefresh.createAutoRefresh({
            intervalMs: 15 * 60 * 1000,
            refresh: () => updateDashboard(true),
        });

        if (!document.hidden) {
            autoRefresh.start();
        }

        document.addEventListener('visibilitychange', () => {
            if (document.hidden) {
                autoRefresh.stop();
            } else {
                autoRefresh.start();
                updateDashboard(true);
            }
        });

        window.addEventListener('focus', () => {
            autoRefresh.start();
            updateDashboard(true);
        });
    }
}
```
**Why:** reuses the existing `updateDashboard(true)` path, which already issues a `?refresh=1` request that bypasses the transient.

### `statify.php`, `readme.txt`, `CHANGELOG.md`
Version bumped to 2.0.3, Stable tag updated, and a 2.0.3 changelog entry added.

## Testing

New automated coverage:

- `tests/js/auto-refresh.test.js`: 4 node:test cases (`start()` fires on the interval, `stop()` prevents further ticks, a rejecting refresh survives and does not stop the timer, `start()` resets a previous timer).
- `tests/test-statify.php::test_localize_auto_refresh`: asserts the `statifyDashboard` payload exposes `autoRefresh` (falsy by default, truthy when enabled).
- `tests/test-settings.php`: sanitize now includes `auto_refresh` (off, on, and a bogus `'2'` coerced to `0`).

Manual verification passes:

1. Enable "Auto-refresh dashboard widget" under Settings > Statify, save.
2. Open the dashboard. With DevTools Network open, the `GET /wp-json/statify/v1/stats?refresh=1` request fires on first focus (the 15-minute tick shows the interval works).
3. Switch to another tab. The timer pauses, no further `?refresh=1` requests fire.
4. Switch back. An immediate `?refresh=1` request fires and the chart updates without a page reload.
5. With the setting off, the chart loads once and stays static; no timers or `focus`/`visibilitychange` requests.
6. Block the stats route in DevTools, reload, and confirm the widget renders an error message, the timer survives, and the next tick recovers.

Environment: WordPress 5.1+, PHP 7.4+. All PHPUnit tests pass (25 tests), PHPCS clean for the changed PHP files, PHPStan clean, ESLint/Stylelint clean for the changed JS, and `npm test` passes (4/4, 96% coverage).