### PR TITLE
Right-align numbers in tables

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -86,6 +86,10 @@
 	width: 80%;
 }
 
+.statify-table .right {
+	text-align: right;
+}
+
 .statify-table + a.button {
 	margin: 1em 0 0 1em;
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -645,6 +645,7 @@
 
 			for (let month = 1; month <= 12; month++) {
 				col = document.createElement('TD');
+				col.classList.add('right');
 				if (month in data.visits[year]) {
 					col.dataset.raw = String(data.visits[year][month]);
 					col.textContent = numberFormat.format(
@@ -659,7 +660,7 @@
 			}
 
 			col = document.createElement('TD');
-			col.classList.add('statify-table-sum');
+			col.classList.add('statify-table-sum', 'right');
 			col.dataset.raw = String(sum);
 			col.textContent = numberFormat.format(sum);
 			row.appendChild(col);

--- a/views/view-content.php
+++ b/views/view-content.php
@@ -147,8 +147,8 @@ if ( ! empty( $date_start ) && ! empty( $date_end ) && $date_start !== $date_end
 				<?php if ( 'popular' === $selected_type ) : ?>
 				<th scope="col"><?php esc_html_e( 'Post Type', 'statify' ); ?></th>
 				<?php endif; ?>
-				<th scope="col"><?php esc_html_e( 'Views', 'statify' ); ?></th>
-				<th scope="col"><?php esc_html_e( 'Proportion', 'statify' ); ?></th>
+				<th scope="col" class="right"><?php esc_html_e( 'Views', 'statify' ); ?></th>
+				<th scope="col" class="right"><?php esc_html_e( 'Proportion', 'statify' ); ?></th>
 			</tr>
 			</thead>
 			<tbody>

--- a/views/view-dashboard.php
+++ b/views/view-dashboard.php
@@ -127,7 +127,7 @@ if ( isset( $_GET['post'] ) ) {
 				<tr>
 					<th scope="col"><?php esc_html_e( 'Year', 'statify' ); ?></th>
 					<?php for ( $mon = 1; $mon <= 12; $mon++ ) : ?>
-					<th scope="col"><?php echo esc_html( date_i18n( 'M', strtotime( '1970-' . $mon . '-01' ) ) ); ?></th>
+					<th scope="col" class="right"><?php echo esc_html( date_i18n( 'M', strtotime( '1970-' . $mon . '-01' ) ) ); ?></th>
 					<?php endfor; ?>
 					<th scope="col" class="right sum"><?php esc_html_e( 'Sum', 'statify' ); ?></th>
 				</tr>
@@ -179,7 +179,7 @@ if ( isset( $_GET['post'] ) ) {
 			<tr>
 				<th><?php esc_html_e( 'Day', 'statify' ); ?></th>
 				<?php for ( $mon = 1; $mon <= 12; $mon++ ) : ?>
-					<th scope="col"><?php echo esc_html( date_i18n( 'M', strtotime( '0000-' . $mon . '-01' ) ) ); ?></th>
+					<th scope="col" class="right"><?php echo esc_html( date_i18n( 'M', strtotime( '0000-' . $mon . '-01' ) ) ); ?></th>
 				<?php endfor; ?>
 			</tr>
 			</thead>
@@ -187,79 +187,79 @@ if ( isset( $_GET['post'] ) ) {
 			<?php for ( $d = 1; $d <= 31; $d++ ) : ?>
 			<tr class="placeholder">
 				<th scope="col"><?php echo esc_html( $d ); ?></th>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
 			</tr>
 			<?php endfor; ?>
 			<tr class="placeholder statify-table-sum">
 				<th scope="col"><?php esc_html_e( 'Sum', 'statify' ); ?></th>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
 			</tr>
 			<tr class="placeholder statify-table-avg">
 				<th scope="col"><?php esc_html_e( 'Average', 'statify' ); ?></th>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
 			</tr>
 			<tr class="placeholder statify-table-min">
 				<th scope="col"><?php esc_html_e( 'Minimum', 'statify' ); ?></th>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
 			</tr>
 			<tr class="placeholder statify-table-max">
 				<th scope="col"><?php esc_html_e( 'Maximum', 'statify' ); ?></th>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
-				<td><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
+				<td class="right"><span>&nbsp;</span></td>
 			</tr>
 			</tbody>
 		</table>

--- a/views/view-referrers.php
+++ b/views/view-referrers.php
@@ -117,8 +117,8 @@ if ( ! empty( $date_start ) && ! empty( $date_end ) && $date_start !== $date_end
 			<thead>
 			<tr>
 				<th scope="col"><?php esc_html_e( 'Referring Domain', 'statify' ); ?></th>
-				<th scope="col"><?php esc_html_e( 'Views', 'statify' ); ?></th>
-				<th scope="col"><?php esc_html_e( 'Proportion', 'statify' ); ?></th>
+				<th scope="col" class="right"><?php esc_html_e( 'Views', 'statify' ); ?></th>
+				<th scope="col" class="right"><?php esc_html_e( 'Proportion', 'statify' ); ?></th>
 			</tr>
 			</thead>
 			<tbody>


### PR DESCRIPTION
Numeric columns in the statistics tables (dashboard widget, "Views"/"Proportion" columns on the content and referrer views) were left-aligned, which made columns of numbers harder to scan at a glance. This MR right-aligns them for better readability, consistent with common table conventions.

Some cells contained the `right` class already which was without effect, as the CSS did not contain a corresponding rule.