### PR TITLE
fix: properly encode CSV data for download (#372)

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -733,8 +733,13 @@
 				)
 			];
 		for (const [m, s] of min.entries()) {
-			out[m].dataset.raw = String(s);
-			out[m].textContent = vls[m] > 0 ? numberFormat.format(s) : '-';
+			if (vls[m] > 0) {
+				out[m].dataset.raw = String(s);
+				out[m].textContent = numberFormat.format(s);
+			} else {
+				out[m].dataset.raw = '';
+				out[m].textContent = '-';
+			}
 		}
 
 		out =
@@ -744,8 +749,13 @@
 				)
 			];
 		for (const [m, s] of max.entries()) {
-			out[m].dataset.raw = vls[m];
-			out[m].textContent = vls[m] > 0 ? numberFormat.format(s) : '-';
+			if (vls[m] > 0) {
+				out[m].dataset.raw = vls[m];
+				out[m].textContent = numberFormat.format(s);
+			} else {
+				out[m].dataset.raw = '';
+				out[m].textContent = '-';
+			}
 		}
 
 		for (const row of rows) {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -908,6 +908,7 @@
 	 */
 	function addExportButton(table) {
 		const exportBtn = document.createElement('a');
+		let csvUrl = null;
 		exportBtn.classList.add('button');
 		exportBtn.href = '#';
 
@@ -927,19 +928,27 @@
 		// Generate CSV on demand.
 		exportBtn.textContent = wp.i18n.__('Export (CSV)', 'statify');
 		exportBtn.addEventListener('click', () => {
-			exportBtn.href =
-				'data:text/csv;charset=utf-8,' +
-				Array.from(table.rows)
-					.map((row) =>
-						Array.from(row.cells)
-							.map(
-								(col) =>
-									col.dataset.raw ??
-									`"${col.innerText.replaceAll('"', '""')}"`
-							)
-							.join(',')
-					)
-					.join('\r\n');
+			if (csvUrl) {
+				URL.revokeObjectURL(csvUrl);
+				csvUrl = null;
+			}
+
+			const csv = Array.from(table.rows)
+				.map((row) =>
+					Array.from(row.cells)
+						.map(
+							(col) =>
+								col.dataset.raw ??
+								`"${col.innerText.replaceAll('"', '""')}"`
+						)
+						.join(',')
+				)
+				.join('\r\n');
+
+			csvUrl = URL.createObjectURL(
+				new Blob([csv], { type: 'text/csv;charset=utf-8' })
+			);
+			exportBtn.href = csvUrl;
 		});
 		table.after(exportBtn);
 	}


### PR DESCRIPTION
Data URIs require encoding (percent or base64). While some Chrome based browser accept raw CSV, including commas, quotes and line breaks, others fail and generate mangled single-line output.

Instead of encoding the payload, we now create a Blob and object URL. This approach also prevents length limitations for larger datasets.

resolves #372

----

Second minor fix while having a closer look on the CSV exports:

omit 0 and `MAX_SAFE_INTEGER` values for min/max rows in CSV export

If a column of the daily stats table does not contain any data, min/max and average are displayed as "-". While for the average the raw value is empty, we add the init values `0` or `9007199254740991` to the raw attribute and export these to CSV. Omit them, too.