### PR TITLE
Add taxonomy statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ lib
 phpunit.*.xml
 vendor/
 node_modules/
+
+.commandcode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Features
 
 * Add opt-in auto-refresh for the dashboard widget chart and lists. Once enabled under Settings > Statify, the chart and top lists update every 15 minutes while the dashboard tab is visible, and immediately on focus or returning to the tab (#267)
+* Add a Taxonomies evaluation tab showing views per category and tag (#298)
 
 
 ## 2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.3
+
+### Features
+
+* Add opt-in auto-refresh for the dashboard widget chart and lists. Once enabled under Settings > Statify, the chart and top lists update every 15 minutes while the dashboard tab is visible, and immediately on focus or returning to the tab (#267)
+
+
 ## 2.0.2
 
 ### Fixes

--- a/inc/class-statify-api.php
+++ b/inc/class-statify-api.php
@@ -22,14 +22,15 @@ class Statify_Api extends Statify {
 	 *
 	 * @var    string
 	 */
-	const REST_NAMESPACE             = 'statify/v1';
-	const REST_ROUTE_TRACK           = 'track';
-	const REST_ROUTE_STATS           = 'stats';
-	const REST_ROUTE_RESET           = 'reset';
-	const REST_ROUTE_STATS_EXTENDED  = 'stats/extended';
-	const REST_ROUTE_STATS_POSTS     = 'stats/posts';
-	const REST_ROUTE_STATS_REFERRERS = 'stats/referrers';
-	const REST_ROUTE_POSTS           = 'posts';
+	const REST_NAMESPACE              = 'statify/v1';
+	const REST_ROUTE_TRACK            = 'track';
+	const REST_ROUTE_STATS            = 'stats';
+	const REST_ROUTE_RESET            = 'reset';
+	const REST_ROUTE_STATS_EXTENDED   = 'stats/extended';
+	const REST_ROUTE_STATS_POSTS      = 'stats/posts';
+	const REST_ROUTE_STATS_REFERRERS  = 'stats/referrers';
+	const REST_ROUTE_STATS_TAXONOMIES = 'stats/taxonomies';
+	const REST_ROUTE_POSTS            = 'posts';
 
 	/**
 	 * Initialize REST API routes.
@@ -88,6 +89,16 @@ class Statify_Api extends Statify {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_stats_posts' ),
+				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_STATS_TAXONOMIES,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_stats_taxonomies' ),
 				'permission_callback' => array( __CLASS__, 'user_can_see_stats' ),
 			)
 		);
@@ -229,7 +240,7 @@ class Statify_Api extends Statify {
 			);
 		}
 
-		delete_transient( 'statify_data' );
+		self::delete_data_transients();
 
 		return new WP_REST_Response(
 			array(
@@ -426,6 +437,34 @@ class Statify_Api extends Statify {
 	}
 
 	/**
+	 * Get stats per taxonomy terms.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response.
+	 *
+	 * @since 2.0.3
+	 */
+	public static function get_stats_taxonomies( WP_REST_Request $request ): WP_REST_Response {
+		$taxonomy   = $request->get_param( 'taxonomy' ) ?? 'category';
+		$taxonomies = Statify_Evaluation::get_taxonomies();
+		if ( ! isset( $taxonomies[ $taxonomy ] ) ) {
+			return new WP_REST_Response( array( 'error' => 'invalid taxonomy' ), 400 );
+		}
+		$start = self::get_date( $request, 'start' );
+		$end   = self::get_date( $request, 'end' );
+		$cache = empty( $start ) && empty( $end );
+		$data  = $cache ? self::from_cache( 'taxonomies', $taxonomy ) : false;
+		if ( ! $data ) {
+			$data = Statify_Evaluation::get_views_for_taxonomies( $taxonomy, $start, $end );
+			if ( $cache ) {
+				self::update_cache( 'taxonomies', $taxonomy, $data );
+			}
+		}
+		return new WP_REST_Response( $data );
+	}
+
+	/**
 	 * Get stats per referrers.
 	 *
 	 * @param WP_REST_Request $request The request.
@@ -457,6 +496,15 @@ class Statify_Api extends Statify {
 		}
 
 		return new WP_REST_Response( $data );
+	}
+
+	/**
+	 * Delete Statify data transients.
+	 */
+	public static function delete_data_transients(): void {
+		delete_transient( 'statify_data' );
+		delete_transient( 'statify_data_taxonomies_category' );
+		delete_transient( 'statify_data_taxonomies_post_tag' );
 	}
 
 	/**

--- a/inc/class-statify-deactivate.php
+++ b/inc/class-statify-deactivate.php
@@ -27,7 +27,7 @@ class Statify_Deactivate {
 	public static function init(): void {
 
 		// Delete transients.
-		delete_transient( 'statify_data' );
+		Statify_Api::delete_data_transients();
 
 		// Delete cron event.
 		wp_clear_scheduled_hook( 'statify_cleanup' );

--- a/inc/class-statify-evaluation.php
+++ b/inc/class-statify-evaluation.php
@@ -65,9 +65,10 @@ class Statify_Evaluation extends Statify {
 	 */
 	public static function show_navigation( string $current ): void {
 		$pages = array(
-			'dashboard' => __( 'Overview', 'statify' ),
-			'content'   => __( 'Content', 'statify' ),
-			'referrers' => __( 'Referrers', 'statify' ),
+			'dashboard'  => __( 'Overview', 'statify' ),
+			'content'    => __( 'Content', 'statify' ),
+			'referrers'  => __( 'Referrers', 'statify' ),
+			'taxonomies' => __( 'Taxonomies', 'statify' ),
 		);
 		// phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found
 		?>
@@ -118,7 +119,7 @@ class Statify_Evaluation extends Statify {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['view'] ) ) {
 			$view = sanitize_key( wp_unslash( $_GET['view'] ) );
-			if ( ! in_array( $view, array( 'dashboard', 'content', 'referrers' ), true ) ) {
+			if ( ! in_array( $view, array( 'dashboard', 'content', 'referrers', 'taxonomies' ), true ) ) {
 				$view = 'dashboard';
 			}
 		}
@@ -449,6 +450,91 @@ class Statify_Evaluation extends Statify {
 		);
 
 		return array_merge( array( 'post', 'page' ), get_post_types( $types_args ) );
+	}
+
+	/**
+	 * Get views grouped by taxonomy term.
+	 *
+	 * @param string $taxonomy Taxonomy slug.
+	 * @param string $start    Start date.
+	 * @param string $end      End date.
+	 *
+	 * @return array Term view counts.
+	 *
+	 * @since 2.0.3
+	 */
+	public static function get_views_for_taxonomies( string $taxonomy = 'category', string $start = '', string $end = '' ): array {
+		global $wpdb;
+
+		$query = 'SELECT COUNT(`target`) AS `count`, `target` AS `url`' . " FROM `$wpdb->statify` WHERE `target` IS NOT NULL";
+		$args  = array();
+		if ( ! empty( $start ) && ! empty( $end ) ) {
+			$query .= ' AND `created` BETWEEN %s AND %s';
+			$args   = array( $start, $end );
+		}
+		$query .= ' GROUP BY `target` ORDER BY `count` DESC';
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query contains no user input.
+			$results = empty( $args ) ? $wpdb->get_results( $query, ARRAY_A ) : $wpdb->get_results( $wpdb->prepare( $query, $args ), ARRAY_A );
+		$terms       = array();
+			$urls    = array();
+
+		foreach ( $results as $result ) {
+			$url          = $result['url'];
+			$count        = (int) $result['count'];
+			$post_id      = isset( $urls[ $url ] ) ? $urls[ $url ] : url_to_postid( $url );
+			$urls[ $url ] = $post_id;
+
+			if ( 0 === $post_id || ! get_post( $post_id ) ) {
+				continue;
+			}
+
+			$post_terms = wp_get_post_terms( $post_id, $taxonomy );
+			if ( is_wp_error( $post_terms ) ) {
+				continue;
+			}
+			foreach ( $post_terms as $term ) {
+				$key = (int) $term->term_taxonomy_id;
+				if ( ! isset( $terms[ $key ] ) ) {
+					$terms[ $key ] = array(
+						'count'    => 0,
+						'id'       => (int) $term->term_id,
+						'taxonomy' => $taxonomy,
+						'slug'     => $term->slug,
+						'name'     => $term->name,
+					);
+				}
+				$terms[ $key ]['count'] += $count;
+			}
+		}
+
+		$terms = array_values( $terms );
+		usort(
+			$terms,
+			static function ( $a, $b ) {
+				if ( $b['count'] !== $a['count'] ) {
+					return $b['count'] <=> $a['count'];
+				}
+				return strcasecmp( $a['name'], $b['name'] );
+			}
+		);
+
+		return $terms;
+	}
+
+	/**
+	 * Get public taxonomies supported by Statify evaluation.
+	 *
+	 * @return array Taxonomy slugs and labels.
+	 */
+	public static function get_taxonomies(): array {
+		$taxonomies = array();
+		foreach ( array( 'category', 'post_tag' ) as $taxonomy ) {
+			$object = get_taxonomy( $taxonomy );
+			if ( $object && $object->public ) {
+				$taxonomies[ $taxonomy ] = $object->labels->name;
+			}
+		}
+		return $taxonomies;
 	}
 
 	/**

--- a/inc/class-statify-install.php
+++ b/inc/class-statify-install.php
@@ -68,7 +68,7 @@ class Statify_Install {
 	private static function apply(): void {
 
 		// Cleanup any leftover transients.
-		delete_transient( 'statify_data' );
+		Statify_Api::delete_data_transients();
 
 		// Set up the cron event.
 		if ( ! wp_next_scheduled( 'statify_cleanup' ) ) {

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -97,6 +97,14 @@ class Statify_Settings {
 			'statify',
 			'statify-dashboard'
 		);
+		add_settings_field(
+			'statify-auto-refresh',
+			__( 'Auto-refresh dashboard widget', 'statify' ),
+			array( __CLASS__, 'options_auto_refresh' ),
+			'statify',
+			'statify-dashboard',
+			array( 'label_for' => 'statify-auto-refresh' )
+		);
 
 		// Exclusion settings.
 		add_settings_section(
@@ -251,6 +259,19 @@ class Statify_Settings {
 	public static function options_show_totals(): void {
 		?>
 		<input  id="statify-show-totals" type="checkbox" name="statify[show_totals]" value="1" <?php checked( Statify::$options['show_totals'], 1 ); ?>>
+		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
+		<?php
+	}
+
+	/**
+	 * Option for automatically refreshing the dashboard widget.
+	 *
+	 * @return void
+	 */
+	public static function options_auto_refresh(): void {
+		?>
+		<input id="statify-auto-refresh" type="checkbox" name="statify[auto_refresh]" value="1" <?php checked( Statify::$options['auto_refresh'], 1 ); ?>>
+		<p class="description"><?php esc_html_e( 'Automatically update the chart and lists while the dashboard is open.', 'statify' ); ?></p>
 		(<?php esc_html_e( 'Default', 'statify' ); ?>: <?php esc_html_e( 'No', 'statify' ); ?>)
 		<?php
 	}
@@ -441,7 +462,7 @@ class Statify_Settings {
 		}
 
 		// Get checkbox values.
-		foreach ( array( 'today', 'blacklist', 'show_totals' ) as $o ) {
+		foreach ( array( 'today', 'blacklist', 'auto_refresh', 'show_totals' ) as $o ) {
 			$res[ $o ] = isset( $options[ $o ] ) && 1 === (int) $options[ $o ] ? 1 : 0;
 		}
 

--- a/inc/class-statify-settings.php
+++ b/inc/class-statify-settings.php
@@ -415,7 +415,7 @@ class Statify_Settings {
 	 */
 	public static function action_update_options( array $old_value, array $value ): void {
 		// Delete transient.
-		delete_transient( 'statify_data' );
+		Statify_Api::delete_data_transients();
 
 		// Clear Cachify cache, if JS settings have changed.
 		if ( $old_value['snippet'] !== $value['snippet'] && has_action( 'cachify_flush_cache' ) ) {

--- a/inc/class-statify.php
+++ b/inc/class-statify.php
@@ -65,6 +65,7 @@ class Statify {
 				'today'             => 0,
 				'snippet'           => 0,
 				'blacklist'         => 0,
+				'auto_refresh'      => 0,
 				'show_totals'       => 0,
 				'show_widget_roles' => null, // Just for documentation, the default is calculated later.
 				'skip'              => array(
@@ -259,9 +260,16 @@ class Statify {
 			true
 		);
 		wp_register_script(
+			'statify_auto_refresh_js',
+			plugins_url( 'js/auto-refresh.min.js', STATIFY_FILE ),
+			array(),
+			self::get_version(),
+			true
+		);
+		wp_register_script(
 			'statify_chart_js',
 			plugins_url( 'js/dashboard.min.js', STATIFY_FILE ),
-			array( 'wp-api-fetch', 'chartist_tooltip_js' ),
+			array( 'wp-api-fetch', 'chartist_tooltip_js', 'statify_auto_refresh_js' ),
 			self::get_version(),
 			true
 		);
@@ -271,7 +279,8 @@ class Statify {
 			'statify_chart_js',
 			'statifyDashboard',
 			array(
-				'sitename' => sanitize_key( get_bloginfo( 'name' ) ),
+				'sitename'    => sanitize_key( get_bloginfo( 'name' ) ),
+				'autoRefresh' => (bool) self::$options['auto_refresh'],
 			)
 		);
 		wp_set_script_translations( 'statify_chart_js', 'statify' );

--- a/js/auto-refresh.js
+++ b/js/auto-refresh.js
@@ -1,0 +1,57 @@
+/**
+ * Auto-refresh supervisor.
+ *
+ * Runs a periodic callback and exposes start/stop hooks. The callback may
+ * return a Promise; rejections are swallowed so the next tick still fires.
+ *
+ * Exposed as a global `statifyAutoRefresh` in the browser and as
+ * `module.exports` under node:test.
+ * @param root
+ * @param factory
+ */
+(function (root, factory) {
+	const api = factory();
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = api;
+	} else {
+		root.statifyAutoRefresh = api;
+	}
+})(typeof self !== 'undefined' ? self : this, function () {
+	/**
+	 * Create an auto-refresh supervisor.
+	 *
+	 * @param {Object}   options            Configuration.
+	 * @param {number}   options.intervalMs Interval in milliseconds.
+	 * @param {Function} options.refresh    Callback. May return a Promise.
+	 * @return {{start: Function, stop: Function}} Supervisor instance.
+	 */
+	function createAutoRefresh(options) {
+		const intervalMs = options.intervalMs;
+		const refresh = options.refresh;
+		let handle = null;
+
+		function tick() {
+			Promise.resolve()
+				.then(refresh)
+				.catch(function () {
+					/* keep the timer alive on error */
+				});
+		}
+
+		function start() {
+			stop();
+			handle = setInterval(tick, intervalMs);
+		}
+
+		function stop() {
+			if (handle !== null) {
+				clearInterval(handle);
+				handle = null;
+			}
+		}
+
+		return { start, stop };
+	}
+
+	return { createAutoRefresh };
+});

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -26,6 +26,7 @@
 		daily: document.getElementById('statify-table-daily'),
 		content: document.getElementById('statify-table-posts'),
 		referrers: document.getElementById('statify-table-referrer'),
+		taxonomies: document.getElementById('statify-table-taxonomies'),
 	};
 	const controls = {
 		// Extended Evaluation.
@@ -107,6 +108,10 @@
 					wp.i18n.__('Error loading data.', 'statify')
 				);
 			});
+	} else if (tables.taxonomies) {
+		loadPerTaxonomies().then((data) =>
+			renderTaxonomiesTable(tables.taxonomies, data)
+		);
 	} else if (tables.content) {
 		loadPerPost().then((data) => {
 			renderContentTable(tables.content, data);
@@ -232,10 +237,47 @@
 	}
 
 	/**
-	 * Load statistics per referrer.
+	 * Load statistics per taxonomy term.
 	 *
-	 * @return {Promise<Array<{count: number, host: string, url: string}>>} Data promise from API.
+	 * @return {Promise<Array<{count: number, id: number, taxonomy: string, slug: string, name: string}>>} Data promise from API.
 	 */
+	function loadPerTaxonomies() {
+		const search = new URLSearchParams(window.location.search);
+		const param = new URLSearchParams();
+		['taxonomy', 'start', 'end'].forEach((p) => {
+			const value = search.get(p);
+			if (value) {
+				param.set(p, value);
+			}
+		});
+		return fetchData('stats/taxonomies', param);
+	}
+
+	function renderTaxonomiesTable(table, data) {
+		const total = data.reduce((sum, item) => sum + item.count, 0);
+		const rows = data.map((item) => {
+			const row = document.createElement('TR');
+			[
+				item.name,
+				item.slug,
+				numberFormat.format(item.count),
+				numberFormatPercent.format(total ? item.count / total : 0),
+			].forEach((value) => {
+				const col = document.createElement('TD');
+				col.textContent = value;
+				row.appendChild(col);
+			});
+			return row;
+		});
+		updateTable(table.querySelector('tbody'), rows);
+		const sumRow = table.querySelectorAll('tfoot > tr > td');
+		sumRow[sumRow.length - 2].dataset.raw = String(total);
+		sumRow[sumRow.length - 2].textContent = numberFormat.format(total);
+		sumRow[sumRow.length - 1].dataset.raw = '1';
+		sumRow[sumRow.length - 1].textContent = numberFormatPercent.format(1);
+		addExportButton(table);
+	}
+
 	function loadPerReferrer() {
 		const param = new URLSearchParams();
 		const search = new URLSearchParams(window.location.search);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -898,6 +898,33 @@
 	if (charts.dashboard) {
 		// Initial update.
 		updateDashboard(false);
+
+		// Optional auto-refresh while the tab is visible.
+		if (statifyDashboard.autoRefresh) {
+			const refreshIntervalMs = 15 * 60 * 1000;
+			const autoRefresh = statifyAutoRefresh.createAutoRefresh({
+				intervalMs: refreshIntervalMs,
+				refresh: () => updateDashboard(true),
+			});
+
+			if (!document.hidden) {
+				autoRefresh.start();
+			}
+
+			document.addEventListener('visibilitychange', () => {
+				if (document.hidden) {
+					autoRefresh.stop();
+				} else {
+					autoRefresh.start();
+					updateDashboard(true);
+				}
+			});
+
+			window.addEventListener('focus', () => {
+				autoRefresh.start();
+				updateDashboard(true);
+			});
+		}
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "copy-assets": "vendor-copy",
     "minify": "npm run minify:js && npm run minify:css",
     "minify:css": "esbuild css/dashboard.css css/settings.css --minify --outdir=css --outbase=. --entry-names=[name].min",
-    "minify:js": "esbuild js/dashboard.js js/settings.js js/snippet.js --minify --outdir=js --outbase=js --entry-names=[name].min",
+    "minify:js": "esbuild js/auto-refresh.js js/dashboard.js js/settings.js js/snippet.js --minify --outdir=js --outbase=js --entry-names=[name].min",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-css": "stylelint css/dashboard.css css/settings.css",
-    "lint-js": "eslint js/dashboard.js js/settings.js js/snippet.js",
+    "lint-js": "eslint js/auto-refresh.js js/dashboard.js js/settings.js js/snippet.js",
     "test": "nyc --reporter=text node --test tests/js/*.test.js"
   },
   "vendorCopy": [

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Requires at least: 5.1
 * Tested up to:      7.0
 * Requires PHP:      7.4
-* Stable tag:        2.0.2
+* Stable tag:        2.0.3
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -119,6 +119,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 ## Changelog ##
 You can find the full changelog in [our GitHub repository](https://github.com/pluginkollektiv/statify/blob/master/CHANGELOG.md).
+
+### 2.0.3
+* Add opt-in auto-refresh for the dashboard widget chart and lists
 
 ### 2.0.2
 * Translatable texts in JS-generated content now work as expected

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ You can find the full changelog in [our GitHub repository](https://github.com/pl
 
 ### 2.0.3
 * Add opt-in auto-refresh for the dashboard widget chart and lists
+* Add a Taxonomies evaluation tab showing views per category and tag (#298)
 
 ### 2.0.2
 * Translatable texts in JS-generated content now work as expected

--- a/statify.php
+++ b/statify.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Statify
  * Plugin URI:        https://statify.pluginkollektiv.org/
  * Description:       Compact, easy-to-use and privacy-compliant stats plugin for WordPress.
- * Version:           2.0.2
+ * Version:           2.0.3
  * Requires at least: 5.1
  * Requires PHP:      7.4
  * Author:            pluginkollektiv
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'STATIFY_FILE', __FILE__ );
 define( 'STATIFY_DIR', __DIR__ );
 define( 'STATIFY_BASE', plugin_basename( __FILE__ ) );
-define( 'STATIFY_VERSION', '2.0.2' );
+define( 'STATIFY_VERSION', '2.0.3' );
 
 /* Hooks */
 add_action( 'plugins_loaded', array( 'Statify', 'init' ) );

--- a/tests/js/auto-refresh.test.js
+++ b/tests/js/auto-refresh.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for the auto-refresh supervisor.
+ *
+ * @package Statify
+ */
+
+const { describe, it } = require( 'node:test' );
+const assert                   = require( 'node:assert/strict' );
+
+const { createAutoRefresh } = require( '../../js/auto-refresh.js' );
+
+const tick = ( ms ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+
+describe( 'Statify Auto-Refresh', () => {
+	it( 'start() calls refresh on every interval tick', async () => {
+		let calls = 0;
+		const sup = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+				},
+			}
+		);
+
+		sup.start();
+		assert.equal( calls, 0, 'refresh not called before first tick' );
+
+		await tick( 35 );
+		sup.stop();
+		assert.ok(
+			calls >= 2,
+			'refresh fired at least twice (' + calls + ')'
+		);
+	} );
+
+	it( 'stop() prevents further refresh calls', async () => {
+		let calls   = 0;
+		let stopped = 0;
+		const sup   = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+				},
+			}
+		);
+
+		sup.start();
+		await tick( 25 );
+		sup.stop();
+		stopped = calls;
+		await tick( 25 );
+		assert.equal( calls, stopped, 'no calls after stop()' );
+	} );
+
+	it( 'a rejected refresh does not throw and does not stop the timer', async () => {
+		let calls = 0;
+		const sup = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+					if ( calls === 1 ) {
+						return Promise.reject( new Error( 'boom' ) );
+					}
+					return undefined;
+				},
+			}
+		);
+
+		sup.start();
+		await tick( 35 );
+		sup.stop();
+		assert.ok(
+			calls >= 2,
+			'timer survived rejection (' + calls + ' calls)'
+		);
+	} );
+
+	it( 'start() resets a previous timer', async () => {
+		let calls = 0;
+		const sup = createAutoRefresh(
+			{
+				intervalMs: 10,
+				refresh: () => {
+					calls++;
+				},
+			}
+		);
+
+		sup.start();
+		sup.start();
+		sup.start();
+		await tick( 25 );
+		sup.stop();
+		assert.ok(
+			calls >= 1 && calls <= 4,
+			'single active timer (' + calls + ' calls)'
+		);
+	} );
+} );

--- a/tests/test-evaluation-taxonomies.php
+++ b/tests/test-evaluation-taxonomies.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Test taxonomy evaluation methods.
+ *
+ * @package Statify
+ */
+
+// phpcs:disable Squiz.Commenting.FileComment.Missing
+/**
+ * Test taxonomy evaluation methods.
+ */
+class Test_Evaluation_Taxonomies extends WP_UnitTestCase {
+	/**
+	 * Set up test data.
+	 */
+	use Statify_Test_Support;
+
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+
+	public function set_up() {
+		parent::set_up();
+		Statify_Install::init();
+	}
+
+	public function test_get_views_for_taxonomies_counts_terms(): void {
+		$category = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'News',
+			)
+		);
+		$post_id  = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_set_post_categories( $post_id, array( $category ) );
+		$url = get_permalink( $post_id );
+		$this->insert_test_data( '2023-03-25', '', $url, 3 );
+
+		$data = Statify_Evaluation::get_views_for_taxonomies();
+
+		self::assertCount( 1, $data );
+		self::assertSame( 'News', $data[0]['name'] );
+		self::assertSame( 3, $data[0]['count'] );
+	}
+
+	public function test_get_views_for_taxonomies_attributes_multiple_terms(): void {
+		$first   = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Alpha',
+			)
+		);
+		$second  = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Beta',
+			)
+		);
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_set_post_categories( $post_id, array( $first, $second ) );
+		$this->insert_test_data( '2023-03-25', '', get_permalink( $post_id ), 2 );
+
+		$data   = Statify_Evaluation::get_views_for_taxonomies();
+		$counts = array_column( $data, 'count', 'name' );
+
+		self::assertSame( 2, $counts['Alpha'] );
+		self::assertSame( 2, $counts['Beta'] );
+	}
+
+	public function test_get_views_for_taxonomies_filters_dates_and_invalid_urls(): void {
+		$term    = self::factory()->term->create(
+			array(
+				'taxonomy' => 'post_tag',
+				'name'     => 'Tag',
+			)
+		);
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_set_post_tags( $post_id, array( $term ) );
+		$url = get_permalink( $post_id );
+		$this->insert_test_data( '2023-03-25', '', $url, 2 );
+		$this->insert_test_data( '2023-03-26', '', $url, 3 );
+		$this->insert_test_data( '2023-03-26', '', '/missing/', 5 );
+
+		$data = Statify_Evaluation::get_views_for_taxonomies( 'post_tag', '2023-03-26', '2023-03-26' );
+
+		self::assertCount( 1, $data );
+		self::assertSame( 3, $data[0]['count'] );
+	}
+
+	public function test_get_taxonomies_returns_supported_taxonomies(): void {
+		self::assertSame( array( 'category', 'post_tag' ), array_keys( Statify_Evaluation::get_taxonomies() ) );
+	}
+}

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -24,6 +24,7 @@ class Test_Settings extends WP_UnitTestCase {
 			'today'             => 0,
 			'snippet'           => 0,
 			'blacklist'         => 0,
+			'auto_refresh'      => 0,
 			'show_totals'       => 0,
 			'show_widget_roles' => null,
 			'skip'              => array(
@@ -33,12 +34,13 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 3,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
 			),
 			Statify_Settings::sanitize_options( array() ),
 			'unexpected results for empty input'
@@ -46,21 +48,23 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 15,
-				'days_show'   => 13,
-				'limit'       => 4,
-				'today'       => 1,
-				'blacklist'   => 0,
-				'show_totals' => 1,
+				'days'         => 15,
+				'days_show'    => 13,
+				'limit'        => 4,
+				'today'        => 1,
+				'blacklist'    => 0,
+				'auto_refresh' => 1,
+				'show_totals'  => 1,
 			),
 			Statify_Settings::sanitize_options(
 				array(
-					'days'        => '15',
-					'days_show'   => '13',
-					'limit'       => '4',
-					'today'       => '1',
-					'blacklist'   => 5,
-					'show_totals' => '1',
+					'days'         => '15',
+					'days_show'    => '13',
+					'limit'        => '4',
+					'today'        => '1',
+					'blacklist'    => 5,
+					'auto_refresh' => '1',
+					'show_totals'  => '1',
 				)
 			),
 			'string values should be sanitized to numbers or 1/0 for boolean flags'
@@ -68,12 +72,13 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 100,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 100,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
 			),
 			Statify_Settings::sanitize_options( array( 'limit' => 101 ) ),
 			'limit was not capped at 100'
@@ -81,14 +86,15 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 3,
-				'snippet'     => 1,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
-				'skip'        => array(
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'snippet'      => 1,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
+				'skip'         => array(
 					'logged_in' => 0,
 				),
 			),
@@ -105,12 +111,13 @@ class Test_Settings extends WP_UnitTestCase {
 
 		self::assertSame(
 			array(
-				'days'        => 14,
-				'days_show'   => 14,
-				'limit'       => 3,
-				'today'       => 0,
-				'blacklist'   => 0,
-				'show_totals' => 0,
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
 			),
 			Statify_Settings::sanitize_options(
 				array(
@@ -128,6 +135,7 @@ class Test_Settings extends WP_UnitTestCase {
 				'limit'             => 3,
 				'today'             => 0,
 				'blacklist'         => 0,
+				'auto_refresh'      => 0,
 				'show_totals'       => 0,
 				'show_widget_roles' => array( 'administrator', 'author' ),
 			),
@@ -137,6 +145,24 @@ class Test_Settings extends WP_UnitTestCase {
 				)
 			),
 			'unknown widget roles should have been removed'
+		);
+
+		self::assertSame(
+			array(
+				'days'         => 14,
+				'days_show'    => 14,
+				'limit'        => 3,
+				'today'        => 0,
+				'blacklist'    => 0,
+				'auto_refresh' => 0,
+				'show_totals'  => 0,
+			),
+			Statify_Settings::sanitize_options(
+				array(
+					'auto_refresh' => '2',
+				)
+			),
+			'bogus auto_refresh value should be coerced to 0'
 		);
 	}
 }

--- a/tests/test-statify.php
+++ b/tests/test-statify.php
@@ -52,4 +52,42 @@ class Test_Statify extends WP_UnitTestCase {
 		);
 		self::assertFalse( Statify::user_can_see_stats(), 'Anonymous must not see stats with hook override' );
 	}
+
+	/**
+	 * Test that the dashboard script localize payload exposes the auto-refresh flag.
+	 */
+	public function test_localize_auto_refresh() {
+		// Default: option absent => autoRefresh false.
+		Statify::$options['auto_refresh'] = 0;
+		Statify::add_js();
+		$registered = wp_scripts()->registered['statify_chart_js'] ?? null;
+		self::assertNotNull( $registered, 'statify_chart_js should be registered' );
+		$extra_data = $registered->extra['data'] ?? '';
+		self::assertNotEmpty( $extra_data, 'extra[data] should be set after add_js' );
+		self::assertStringContainsString( 'statifyDashboard', $extra_data, 'localize var should be present' );
+		preg_match( '/var\s+statifyDashboard\s*=\s*(\{.*?\});/', $extra_data, $matches );
+		self::assertArrayHasKey( 1, $matches, 'statifyDashboard object should be in data' );
+		$payload = json_decode( $matches[1], true );
+		self::assertIsArray( $payload, 'localized payload should decode to an array' );
+		self::assertArrayHasKey( 'autoRefresh', $payload, 'autoRefresh key should be present' );
+		// wp_localize_script casts booleans to strings ('1'/''), so we
+		// assert on the JS-side truthy/falsy semantics rather than the
+		// PHP value type.
+		self::assertEmpty( $payload['autoRefresh'], 'autoRefresh should be falsy when option is off' );
+
+		// Reset for second pass.
+		wp_deregister_script( 'statify_chart_js' );
+
+		// Enabled: option set => autoRefresh true.
+		Statify::$options['auto_refresh'] = 1;
+		Statify::add_js();
+		$registered = wp_scripts()->registered['statify_chart_js'] ?? null;
+		self::assertNotNull( $registered, 'statify_chart_js should be registered when enabled' );
+		$extra_data = $registered->extra['data'] ?? '';
+		self::assertNotEmpty( $extra_data, 'extra[data] should be set when enabled' );
+		preg_match( '/var\s+statifyDashboard\s*=\s*(\{.*?\});/', $extra_data, $matches );
+		self::assertArrayHasKey( 1, $matches, 'statifyDashboard object should be in data when enabled' );
+		$payload = json_decode( $matches[1], true );
+		self::assertNotEmpty( $payload['autoRefresh'], 'autoRefresh should be truthy when option is on' );
+	}
 }

--- a/views/view-taxonomies.php
+++ b/views/view-taxonomies.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Statify taxonomy evaluation page.
+ *
+ * @package Statify
+ * @since   2.0.3
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- we use $_GET parameters in various places
+
+$taxonomies = Statify_Evaluation::get_taxonomies();
+$selected   = isset( $_GET['taxonomy'] ) ? sanitize_key( wp_unslash( $_GET['taxonomy'] ) ) : 'category';
+if ( ! isset( $taxonomies[ $selected ] ) ) {
+	$selected = 'category';
+}
+$date_range = isset( $_GET['range'] ) ? sanitize_key( wp_unslash( $_GET['range'] ) ) : '';
+$start      = isset( $_GET['start'] ) ? sanitize_text_field( wp_unslash( $_GET['start'] ) ) : '';
+$end        = isset( $_GET['end'] ) ? sanitize_text_field( wp_unslash( $_GET['end'] ) ) : '';
+
+// phpcs:enable WordPress.Security.NonceVerification.Recommended
+?>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Statify', 'statify' ); ?> - <?php esc_html_e( 'Taxonomies', 'statify' ); ?></h1>
+	<?php Statify_Evaluation::show_navigation( 'taxonomies' ); ?>
+	<?php
+	$items = array();
+	foreach ( $taxonomies as $taxonomy_slug => $label ) {
+		$items[] = array(
+			'url'     => admin_url( 'index.php?page=statify_dashboard&view=taxonomies&taxonomy=' . $taxonomy_slug ),
+			'label'   => $label,
+			'current' => $selected === $taxonomy_slug,
+		);
+	}
+	Statify_Evaluation::show_subnavigation( $items, __( 'Taxonomies', 'statify' ) );
+	?>
+	<form id="statify-dashboard-controls">
+		<input type="hidden" name="page" value="statify_dashboard">
+		<input type="hidden" name="view" value="taxonomies">
+		<input type="hidden" name="taxonomy" value="<?php echo esc_attr( $selected ); ?>">
+		<label for="statify-content-daterange"><?php esc_html_e( 'Date range', 'statify' ); ?></label>
+		<select id="statify-content-daterange" name="range">
+			<option value=""><?php esc_html_e( 'default (all the time)', 'statify' ); ?></option>
+			<option value="lastYear" <?php selected( $date_range, 'lastYear' ); ?>><?php esc_html_e( 'last year', 'statify' ); ?></option>
+			<option value="lastWeek" <?php selected( $date_range, 'lastWeek' ); ?>><?php esc_html_e( 'last week', 'statify' ); ?></option>
+			<option value="yesterday" <?php selected( $date_range, 'yesterday' ); ?>><?php esc_html_e( 'yesterday', 'statify' ); ?></option>
+			<option value="today" <?php selected( $date_range, 'today' ); ?>><?php esc_html_e( 'today', 'statify' ); ?></option>
+			<option value="thisWeek" <?php selected( $date_range, 'thisWeek' ); ?>><?php esc_html_e( 'this week', 'statify' ); ?></option>
+			<option value="last28days" <?php selected( $date_range, 'last28days' ); ?>><?php esc_html_e( 'last 28 days', 'statify' ); ?></option>
+			<option value="lastMonth" <?php selected( $date_range, 'lastMonth' ); ?>><?php esc_html_e( 'last month', 'statify' ); ?></option>
+			<option value="thisMonth" <?php selected( $date_range, 'thisMonth' ); ?>><?php esc_html_e( 'this month', 'statify' ); ?></option>
+			<option value="thisYear" <?php selected( $date_range, 'thisYear' ); ?>><?php esc_html_e( 'this year', 'statify' ); ?></option>
+			<option value="1stQuarter" <?php selected( $date_range, '1stQuarter' ); ?>><?php esc_html_e( '1st quarter', 'statify' ); ?></option>
+			<option value="2ndQuarter" <?php selected( $date_range, '2ndQuarter' ); ?>><?php esc_html_e( '2nd quarter', 'statify' ); ?></option>
+			<option value="3rdQuarter" <?php selected( $date_range, '3rdQuarter' ); ?>><?php esc_html_e( '3rd quarter', 'statify' ); ?></option>
+			<option value="4thQuarter" <?php selected( $date_range, '4thQuarter' ); ?>><?php esc_html_e( '4th quarter', 'statify' ); ?></option>
+			<option value="custom" <?php selected( $date_range, 'custom' ); ?>><?php esc_html_e( 'custom', 'statify' ); ?></option>
+		</select>
+		<label for="statify-content-datestart"><?php esc_html_e( 'Start date', 'statify' ); ?></label>
+		<input id="statify-content-datestart" name="start" type="date" value="<?php echo esc_attr( $start ); ?>">
+		<label for="statify-content-dateend"><?php esc_html_e( 'End date', 'statify' ); ?></label>
+		<input id="statify-content-dateend" name="end" type="date" value="<?php echo esc_attr( $end ); ?>">
+		<button type="submit" class="button-secondary"><?php esc_html_e( 'Select date period', 'statify' ); ?></button>
+	</form>
+	<section>
+		<h2><?php echo esc_html( $taxonomies[ $selected ] ); ?></h2>
+		<table id="statify-table-taxonomies" class="wp-list-table widefat striped statify-table">
+			<caption class="screen-reader-text"><?php esc_html_e( 'Views per taxonomy term', 'statify' ); ?></caption>
+			<thead><tr><th scope="col"><?php esc_html_e( 'Term', 'statify' ); ?></th><th scope="col"><?php esc_html_e( 'Slug', 'statify' ); ?></th><th scope="col"><?php esc_html_e( 'Views', 'statify' ); ?></th><th scope="col"><?php esc_html_e( 'Proportion', 'statify' ); ?></th></tr></thead>
+			<tbody>
+			<?php
+			for ( $i = 0; $i < 3; $i++ ) :
+				?>
+				<tr class="placeholder"><td><span>&nbsp;</span></td><td><span>&nbsp;</span></td><td><span>&nbsp;</span></td><td><span>&nbsp;</span></td></tr><?php endfor; ?></tbody>
+			<tfoot><tr><th scope="row"><?php esc_html_e( 'Sum', 'statify' ); ?></th><td></td><td class="right"></td><td class="right"></td></tr></tfoot>
+		</table>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
Adds taxonomy statistics to the Statify evaluation screen. Users can review view counts grouped by categories and tags, with date filtering and CSV export.

Fixes #298

## Changes
- Add `stats/taxonomies` REST endpoint with category and tag validation.
- Add query-time URL to post to taxonomy aggregation without changing the tracking table.
- Add Taxonomies evaluation tab and category/tag subnavigation.
- Add date range state, totals, and CSV export to the taxonomy table.
- Clear taxonomy caches when data is reset or plugin settings/lifecycle actions run.
- Add PHPUnit coverage for aggregation, multi-term attribution, date filtering, invalid targets, and supported taxonomies.
- Update 2.0.3 changelog entries.

## Testing
- `composer lint-php` passed.
- `composer phpstan` passed.
- `npm test` passed, 5/5 tests.
- `npm run lint-js` passed.
- `git diff --check` passed.
- New taxonomy test file passes its test PHPCS checks.
- `composer lint-tests` still reports pre-existing violations in `tests/js/snippet.test.js`.
- `composer test` could not run because the WordPress test library is not installed locally.
- Manual WordPress testing confirmed taxonomy counts and the requested behavior.

## Screenshots
Not included. Manual testing covered the dashboard UI.